### PR TITLE
Fix FastRuby logo not showing in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Sponsorship
 
-![FastRuby.io | Rails Upgrade Services](https://github.com/fastruby/points/raw/master/app/assets/images/fastruby-logo.png)
+![FastRuby.io | Rails Upgrade Services](https://github.com/fastruby/points/raw/main/app/assets/images/fastruby-logo.png)
 
 
 `Points` is maintained and funded by [FastRuby.io](https://fastruby.io). The names and logos for FastRuby.io are trademarks of The Lean Software Boutique LLC.


### PR DESCRIPTION
Hey! I noticed that the FastRuby logo in the README file was not showing. It's because the link broke after renaming the `master` branch to `main`. This PR fixes it 🤙

Before:
![Screen Shot 2020-10-06 at 3 16 58 PM](https://user-images.githubusercontent.com/7442887/95243470-1371d880-07e7-11eb-895c-15a9f772a2c4.png)

Now:
![Screen Shot 2020-10-06 at 3 16 49 PM](https://user-images.githubusercontent.com/7442887/95243483-17055f80-07e7-11eb-9b5f-95de96ffa886.png)

Please check it out. Thanks!