### PR TITLE
Fix GitHub login

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ if next?
 else
   gem 'omniauth-github'
 end
+gem "omniauth-rails_csrf_protection"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (2.0.2)
+    omniauth (2.0.3)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
       rack-protection
@@ -191,6 +191,9 @@ GEM
     omniauth-oauth2 (1.7.1)
       oauth2 (~> 1.4)
       omniauth (>= 1.9, < 3)
+    omniauth-rails_csrf_protection (1.0.0)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     orm_adapter (0.5.0)
     parallel (1.20.1)
     parser (3.0.0.0)
@@ -364,6 +367,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   next_rails
   omniauth-github
+  omniauth-rails_csrf_protection
   pg (~> 0.18)
   puma (~> 3.7)
   rails (~> 5.2.3)

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -105,6 +105,10 @@ GEM
       capybara (>= 1.0, < 4)
       launchy
     childprocess (3.0.0)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.12.2)
     colorize (0.8.1)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
@@ -188,6 +192,9 @@ GEM
     omniauth-oauth2 (1.7.1)
       oauth2 (~> 1.4)
       omniauth (>= 1.9, < 3)
+    omniauth-rails_csrf_protection (1.0.0)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     orm_adapter (0.5.0)
     parallel (1.20.1)
     parser (3.0.0.0)
@@ -334,6 +341,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (4.6.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -352,6 +363,7 @@ DEPENDENCIES
   byebug
   capybara
   capybara-screenshot
+  coffee-script
   database_cleaner
   devise!
   dotenv-rails
@@ -363,6 +375,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   next_rails
   omniauth-github (~> 2.0.0)
+  omniauth-rails_csrf_protection
   pg (~> 0.18)
   puma (~> 3.7)
   rails (~> 6.0.3.4)
@@ -371,7 +384,6 @@ DEPENDENCIES
   redcarpet (~> 3.0.0)
   rspec-rails (~> 4.0.2)
   sass-rails (~> 5.0)
-  selenium-webdriver
   shoulda-matchers (~> 3.1)
   simplecov
   spring
@@ -381,6 +393,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webdrivers
 
 BUNDLED WITH
    1.17.3

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -7,7 +7,7 @@
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), class: "button", id:"back" %><br />
+    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), class: "button", id:"back", method: :post %><br />
   <% end -%>
 <% end -%>
 </div>


### PR DESCRIPTION
**Description:**

This PR fixes the login with GitHub. Omniauth 2.0.0 changed the default authentication METHOD required from GET to POST. Then, to handle the CSRF token properly, it needs the new `omniauth-rails_crsf_protection` gem too.

More details here on the release notes: https://github.com/omniauth/omniauth/releases/tag/v2.0.0

NOTE: I already deployed this to staging to test it and it's working for me! https://points-staging.herokuapp.com/

**How to test/QA**

Just go to staging and try to login (or logout and re-login)

I will abide by the [code of conduct](https://github.com/fastruby/points/CODE_OF_CONDUCT.md).
