### PR TITLE
Feature/fixed add story button

### DIFF
--- a/app/assets/stylesheets/3-atoms/_buttons.scss
+++ b/app/assets/stylesheets/3-atoms/_buttons.scss
@@ -8,6 +8,8 @@
 	transition: $hover_transition_time;
 	transition-property: background, color;
 	border: none;
+  font-weight: normal;
+
 	&:hover, &:active{
 		background-color: lighten($orange, 10%);
 	}

--- a/app/assets/stylesheets/4-molecules/_tables.scss
+++ b/app/assets/stylesheets/4-molecules/_tables.scss
@@ -1,6 +1,14 @@
 .project-table {
   display: grid;
   padding: 50px 0;
+  &__header {
+    position: sticky;
+    background: #ffffff;
+    z-index: 1;
+    top: 54px;
+    margin-left: -20px;
+    padding-left: 20px;
+  }
   .project-table__row {
     display: grid;
     grid-template-columns: 40% 10% 10% auto;

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -5,12 +5,12 @@
   <% end %>
 
   <table class="project-table">
-    <thead>
+    <thead class="project-table__header">
       <tr class="project-table__row project-table__row--header">
-        <td class="project-table__cell">Story Title</td>
-        <td class="project-table__cell">Best Estimate</td>
-        <td class="project-table__cell">Worst Estimate</td>
-        <td class="project-table__cell"> <button id="bulk_delete" class="button magenta">Delete</button></td>
+        <th class="project-table__cell">Story Title</th>
+        <th class="project-table__cell">Best Estimate</th>
+        <th class="project-table__cell">Worst Estimate</th>
+        <th class="project-table__cell"> <button id="bulk_delete" class="button magenta">Delete</button></th>
       </tr>
     </thead>
 

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -10,7 +10,10 @@
         <th class="project-table__cell">Story Title</th>
         <th class="project-table__cell">Best Estimate</th>
         <th class="project-table__cell">Worst Estimate</th>
-        <th class="project-table__cell"> <button id="bulk_delete" class="button magenta">Delete</button></th>
+        <th class="project-table__cell">
+          <%= link_to "Add a Story", new_project_story_path(@project.id), class: "button magenta"  %>
+          <button id="bulk_delete" class="button magenta">Delete</button>
+        </th>
       </tr>
     </thead>
 
@@ -56,7 +59,6 @@
   <%= render partial: "projects/import_export" %>
 
   <div class="btn-group">
-    <%= link_to "Add a Story", new_project_story_path(@project.id), class: "button magenta"  %>
     <%= link_to "Edit or Delete Project", edit_project_path(@project.id), class: "button magenta"  %>
 
     <% unless @project.parent_id %>


### PR DESCRIPTION
**Description:**
_Closes#21_

Make the projects table header sticky.
Move the Add a Story button to the new sticky header.

Now project header row always shows making it easy to which column belongs to which header.
Any button in the header is also visible at all times.

**Notes**
Moving the add button might confuse existing users so this might be something to reconsider?

** Screenshots**
New Project:
![image](https://user-images.githubusercontent.com/3785596/111446806-7318cc00-8715-11eb-94c9-c141f2d283bf.png)

Project with stories:
![image](https://user-images.githubusercontent.com/3785596/111446856-82981500-8715-11eb-9c4e-d245d0d5ad61.png)

I will abide by the [code of conduct](https://github.com/fastruby/points/CODE_OF_CONDUCT.md).
