### PR TITLE
Fix/csv import export UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ config/database.yml
 coverage
 .env
 .byebug_history
+.tool-versions

--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -16,6 +16,10 @@ document.addEventListener("turbolinks:load", function() {
     }
   })
 
+  $(".import-export-header").click(function () {
+    $(this).children(".rotate").toggleClass("left");
+  })
+
   $("#bulk_delete").click((event) => {
     let stories_ids = []
     $("input[name='stories[]']:checked").each((_, checkbox) => {

--- a/app/assets/stylesheets/2-quarks/_icons.scss
+++ b/app/assets/stylesheets/2-quarks/_icons.scss
@@ -1,7 +1,13 @@
 /* === ICONS */
 /* ========================== */
 
+.rotate {
+  transition: all 0.1s linear;
+}
+.rotate.left {
+  transform: rotate(180deg);
+}
 
 .features .fa {
-	color: #333;
+  color: #333;
 }

--- a/app/assets/stylesheets/project.scss
+++ b/app/assets/stylesheets/project.scss
@@ -2,13 +2,13 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.projects-controller{
-  &.index-action{
-    .btn-group{
+.projects-controller {
+  &.index-action {
+    .btn-group {
       display: flex;
       justify-content: center;
       margin-top: 20px;
-      .button{
+      .button {
         margin: 0 5px;
       }
     }
@@ -19,21 +19,41 @@
   font-weight: bold;
 }
 
-#import-export{
+#import-export {
   margin: 0 0 50px 0;
-  summary{
-    h4{
+  summary {
+    h4 {
       display: inline-block;
     }
   }
-  section{
+  section {
     background-color: $white;
-    padding:15px;
+    padding: 15px;
     margin: 5px 0 60px 0;
-    input{
-      display: inline-block; 
+    input {
+      display: inline-block;
       margin: 0 0 10px 0;
     }
+  }
+}
+
+.import-export-header {
+  transition: all 0.2s linear;
+  cursor: pointer;
+  outline: transparent;
+
+  & &__text {
+    padding-left: 1rem;
+    vertical-align: bottom;
+  }
+
+  &:hover {
+    transform: translateY(-2px);
+  }
+
+  &::-webkit-details-marker {
+    // Remove Safari/Webkit summary marker
+    display: none;
   }
 }
 
@@ -49,7 +69,7 @@
   display: flex;
   .card {
     padding-right: 40px;
-    .card-header{
+    .card-header {
       margin-bottom: 10px;
     }
   }

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -26,6 +26,18 @@ class ProjectsController < ApplicationController
     Project.find(params[:id]).toggle_archived!
   end
 
+  def duplicate
+    original = Project.includes(stories: :estimates).find(params[:id])
+    duplicate = original.dup
+    duplicate.title = "Copy of #{original.title}"
+    duplicate.save
+
+    original.stories.each { |x| duplicate.stories.create(x.dup.attributes) }
+
+    flash[:success] = 'Project created!'
+    redirect_to "/projects/#{duplicate.id}"
+  end
+
   def create
     @project = Project.new(projects_params)
     if @project.save

--- a/app/views/projects/_import_export.html.erb
+++ b/app/views/projects/_import_export.html.erb
@@ -1,5 +1,7 @@
 <details id="import-export">
-  <summary><h4>CSV Import / Export</h4></summary>
+  <summary class="import-export-header"">
+    <i class="fa fa-lg fa-chevron-down rotate"></i>
+    <h4 class="import-export-header__text">CSV Import / Export</h4> </summary>
   <section>
     <div id="import" class="card-deck mb-3">
       <div class="card mb-6 box-shadow">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -64,6 +64,7 @@
     <% unless @project.parent_id %>
       <%= link_to 'Add Sub-Project', project_new_sub_project_path(@project.id), id:"subproject", class: "button magenta" %>
     <% end %>
+    <%= link_to 'Clone Project', duplicate_project_path(@project.id), method: :post, disable_with: 'Cloning...', class: "button magenta" %>
     <%= link_to "Archive Project", toggle_archive_project_path(@project.id), method: "patch", id: "toggle_archive", class: "button magenta", remote: true %>
     <%= link_to "Generate Action Plan", project_action_plan_path(@project.id), class: "button" %>
     <% if current_user.admin? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     patch :sort, on: :member
     patch :toggle_archive, on: :member
     get :new_sub_project
+    post :duplicate, on: :member
 
     resource :report do
       get "download", to: "reports#download"

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -144,4 +144,44 @@ RSpec.describe ProjectsController, type: :controller do
       expect(project.reload.title).to eq "New Project Title"
     end
   end
+
+  describe 'duplicate' do
+    context 'with a project' do
+      before do
+        post :duplicate, params: { id: project.id }
+      end
+
+      it 'creates a duplicate project' do
+        expect(Project.last.title).to eq "Copy of #{project.title}"
+      end
+
+      it 'redirects to new project' do
+        expect(response).to redirect_to "/projects/#{Project.last.id}"
+      end
+
+      it 'adds a success message' do
+        expect(flash[:success]).to be_present
+      end
+    end
+
+    context 'with stories' do
+      it 'creates a duplicate project with matching stories' do
+        story = project.stories.create({ title: 'Story 1' })
+
+        post :duplicate, params: { id: project.id }
+
+        expect(Project.last.stories.first.id).not_to eq story.id
+        expect(Project.last.stories.first.title).to eq story.title
+      end
+
+      it 'creates stories without estimates' do
+        story = project.stories.create({ title: 'Story 1' })
+        story.estimates.create({ best_case_points: 1, worst_case_points: 3 })
+
+        post :duplicate, params: { id: project.id }
+
+        expect(Project.last.stories.first.estimates).to be_empty
+      end
+    end
+  end
 end

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe "managing projects" do
     expect(Project.count).to eq 1
   end
 
+  it "allows me to clone a project" do
+    visit project_path(id: project.id)
+    click_link "Clone Project"
+    expect(Project.count).to eq 2
+    expect(Project.last.title).to eq "Copy of #{project.title}"
+  end
+
   it "allows me to edit a project" do
     visit project_path(id: project.id)
     click_link "Edit or Delete Project"


### PR DESCRIPTION
**Description:**

_Closes #35 _

Add icon and hover effect to indicate that the CSV import/export header is clickable.

https://user-images.githubusercontent.com/3785596/119365060-d8f27880-bcaf-11eb-8f1e-d03b49b2527d.mov

**Note:**
Added to gitignore
Had to update mimemagic before I could bundle install.
The additional commits come from: https://github.com/fastruby/points/pull/42

**QA**
Test the CSV import/expansion panel.
Is it obviously clickable?
Does it work when you reload the page?

I will abide by the [code of conduct](https://github.com/fastruby/points/CODE_OF_CONDUCT.md).
