### PR TITLE
Feature/project duplicate

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -21,6 +21,18 @@ class ProjectsController < ApplicationController
     head :ok
   end
 
+  def duplicate
+    original = Project.includes(stories: :estimates).find(params[:id])
+    duplicate = original.dup
+    duplicate.title = "Copy of #{original.title}"
+    duplicate.save
+
+    original.stories.each { |x| duplicate.stories.create(x.dup.attributes) }
+
+    flash[:success] = 'Project created!'
+    redirect_to "/projects/#{duplicate.id}"
+  end
+
   def create
     @project = Project.new(projects_params)
     if @project.save

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -65,6 +65,8 @@
       <%= link_to 'Add Sub-Project', project_new_sub_project_path(@project.id), id:"subproject", class: "button magenta" %>
     <% end %>
 
+    <%= link_to 'Clone Project', duplicate_project_path(@project.id), method: :post, disable_with: 'Cloning...', class: "button magenta" %>
+
     <%= link_to "Generate Action Plan", project_action_plan_path(@project.id), class: "button" %>
     <% if current_user.admin? %>
       <%= link_to "View Report", project_report_path(@project.id), class: "button"  %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   resources :projects do
     patch :sort, on: :member
     get :new_sub_project
+    post :duplicate, on: :member
 
     resource :report do
       get 'download', to: 'reports#download'

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -132,4 +132,44 @@ RSpec.describe ProjectsController, type: :controller do
       expect(project.reload.title).to eq "New Project Title"
     end
   end
+
+  describe 'duplicate' do
+    context 'with a project' do
+      before do
+        post :duplicate, params: { id: project.id }
+      end
+
+      it 'creates a duplicate project' do
+        expect(Project.last.title).to eq "Copy of #{project.title}"
+      end
+
+      it 'redirects to new project' do
+        expect(response).to redirect_to "/projects/#{Project.last.id}"
+      end
+
+      it 'adds a success message' do
+        expect(flash[:success]).to be_present
+      end
+    end
+
+    context 'with stories' do
+      it 'creates a duplicate project with matching stories' do
+        story = project.stories.create({ title: 'Story 1' })
+
+        post :duplicate, params: { id: project.id }
+
+        expect(Project.last.stories.first.id).not_to eq story.id
+        expect(Project.last.stories.first.title).to eq story.title
+      end
+
+      it 'creates stories without estimates' do
+        story = project.stories.create({ title: 'Story 1' })
+        story.estimates.create({ best_case_points: 1, worst_case_points: 3 })
+
+        post :duplicate, params: { id: project.id }
+
+        expect(Project.last.stories.first.estimates).to be_empty
+      end
+    end
+  end
 end

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -21,6 +21,13 @@ RSpec.describe "managing projects" do
     expect(Project.count).to eq 1
   end
 
+  it "allows me to clone a project" do
+    visit project_path(id: project.id)
+    click_link "Clone Project"
+    expect(Project.count).to eq 2
+    expect(Project.last.title).to eq "Copy of #{project.title}"
+  end
+
   it "allows me to edit a project" do
     visit project_path(id: project.id)
     click_link "Edit or Delete Project"


### PR DESCRIPTION
**Description:**

This PR closes: https://github.com/fastruby/points/issues/33

It adds a route and action for duplicating projects.
It adds a button that posts to the duplicate route.

A new `Clone Project` button was added.
Before:
![image](https://user-images.githubusercontent.com/3785596/119545405-12e87b00-bd93-11eb-8f73-4b01bc35f9d3.png)

After:
![image](https://user-images.githubusercontent.com/3785596/119545286-f0eef880-bd92-11eb-9416-6f560b5dc9f5.png)

![image](https://user-images.githubusercontent.com/3785596/119545548-3c090b80-bd93-11eb-8ccd-78b5da8ae953.png)

I will abide by the [code of conduct](https://github.com/fastruby/points/CODE_OF_CONDUCT.md).