### PR TITLE
Renames 'Delete' to 'Bulk Delete' and adds visual cues

### DIFF
--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -1,4 +1,4 @@
-$(() => {
+document.addEventListener("turbolinks:load", function() {
   $("input[name='stories[]']").click(() => {
     let selected = $("input[name='stories[]']:checked");
 

--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -1,10 +1,17 @@
 $(() => {
   $("input[name='stories[]']").click(() => {
     let selected = $("input[name='stories[]']:checked");
-    let ending = selected.length == 1 ? "y" : "ies";
-    $(".number-of-stories-selected")
-      .text(`${selected.length} stor${ending} selected`)
-      .removeClass("alert");
+
+    if (selected.length > 0) {
+      let ending = selected.length == 1 ? "y" : "ies";
+      $("#bulk_delete")
+        .text(`Bulk Delete (${selected.length} Stor${ending})`)
+        .removeAttr("aria-disabled");
+    } else {
+      $("#bulk_delete")
+        .text(`Bulk Delete`)
+        .attr("aria-disabled", "true");
+    }
   })
 
   $("#bulk_delete").click(() => {
@@ -12,12 +19,6 @@ $(() => {
     $("input[name='stories[]']:checked").each((_, checkbox) => {
       stories_ids.push($(checkbox).val())
     })
-
-    if (stories_ids.length === 0) {
-      $(".number-of-stories-selected")
-        .text("Please select 1 or more stories")
-        .addClass("alert");
-    }
 
     let token = $("meta[name='csrf-token']").attr("content")
     $.ajaxSetup({
@@ -33,7 +34,6 @@ $(() => {
       success: () => {
         $(stories_ids).each((_, id) => {
           console.log(id)
-          $(".number-of-stories-selected").text("");
           $("#story_" + id).remove();
         })
       },

--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -20,12 +20,6 @@ $(() => {
       stories_ids.push($(checkbox).val())
     })
 
-    if (stories_ids.length === 0) {
-      $(".number-of-stories-selected")
-        .text("Please select 1 or more stories")
-        .addClass("alert");
-    }
-
     let token = $("meta[name='csrf-token']").attr("content")
     $.ajaxSetup({
       beforeSend: function (xhr) {
@@ -40,7 +34,6 @@ $(() => {
       success: () => {
         $(stories_ids).each((_, id) => {
           console.log(id)
-          $(".number-of-stories-selected").text("");
           $("#story_" + id).remove();
         })
       },

--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -1,9 +1,9 @@
 document.addEventListener("turbolinks:load", function() {
   $("input[name='stories[]']").click(() => {
-    let selected = $("input[name='stories[]']:checked");
+    const selected = $("input[name='stories[]']:checked");
 
     if (selected.length > 0) {
-      let ending = selected.length == 1 ? "y" : "ies";
+      const ending = selected.length == 1 ? "y" : "ies";
       $("#bulk_delete")
         .text(`Bulk Delete (${selected.length} Stor${ending})`)
         .removeAttr("aria-disabled");

--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -6,11 +6,13 @@ document.addEventListener("turbolinks:load", function() {
       const ending = selected.length == 1 ? "y" : "ies";
       $("#bulk_delete")
         .text(`Bulk Delete (${selected.length} Stor${ending})`)
-        .removeAttr("aria-disabled");
+        .attr("aria-disabled", "false")
+        .prop("disabled", false);
     } else {
       $("#bulk_delete")
         .text("Bulk Delete")
-        .attr("aria-disabled", "true");
+        .attr("aria-disabled", "true")
+        .prop("disabled", true)
     }
   })
 
@@ -22,7 +24,8 @@ document.addEventListener("turbolinks:load", function() {
 
     $(event.target)
       .text("Bulk Delete")
-      .attr("aria-disabled", "true");
+      .attr("aria-disabled", "true")
+      .prop("disabled", true)
 
     let token = $("meta[name='csrf-token']").attr("content")
     $.ajaxSetup({

--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -20,6 +20,12 @@ $(() => {
       stories_ids.push($(checkbox).val())
     })
 
+    if (stories_ids.length === 0) {
+      $(".number-of-stories-selected")
+        .text("Please select 1 or more stories")
+        .addClass("alert");
+    }
+
     let token = $("meta[name='csrf-token']").attr("content")
     $.ajaxSetup({
       beforeSend: function (xhr) {
@@ -34,6 +40,7 @@ $(() => {
       success: () => {
         $(stories_ids).each((_, id) => {
           console.log(id)
+          $(".number-of-stories-selected").text("");
           $("#story_" + id).remove();
         })
       },

--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -14,11 +14,15 @@ document.addEventListener("turbolinks:load", function() {
     }
   })
 
-  $("#bulk_delete").click(() => {
+  $("#bulk_delete").click((event) => {
     let stories_ids = []
     $("input[name='stories[]']:checked").each((_, checkbox) => {
       stories_ids.push($(checkbox).val())
     })
+
+    $(event.target)
+      .text("Bulk Delete")
+      .attr("aria-disabled", "true");
 
     let token = $("meta[name='csrf-token']").attr("content")
     $.ajaxSetup({

--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -1,9 +1,23 @@
 $(() => {
+  $("input[name='stories[]']").click(() => {
+    let selected = $("input[name='stories[]']:checked");
+    let ending = selected.length == 1 ? "y" : "ies";
+    $(".number-of-stories-selected")
+      .text(`${selected.length} stor${ending} selected`)
+      .removeClass("alert");
+  })
+
   $("#bulk_delete").click(() => {
     let stories_ids = []
     $("input[name='stories[]']:checked").each((_, checkbox) => {
       stories_ids.push($(checkbox).val())
     })
+
+    if (stories_ids.length === 0) {
+      $(".number-of-stories-selected")
+        .text("Please select 1 or more stories")
+        .addClass("alert");
+    }
 
     let token = $("meta[name='csrf-token']").attr("content")
     $.ajaxSetup({
@@ -19,6 +33,7 @@ $(() => {
       success: () => {
         $(stories_ids).each((_, id) => {
           console.log(id)
+          $(".number-of-stories-selected").text("");
           $("#story_" + id).remove();
         })
       },
@@ -28,8 +43,3 @@ $(() => {
     })
   })
 })
-
-
-
-
-

--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -9,7 +9,7 @@ document.addEventListener("turbolinks:load", function() {
         .removeAttr("aria-disabled");
     } else {
       $("#bulk_delete")
-        .text(`Bulk Delete`)
+        .text("Bulk Delete")
         .attr("aria-disabled", "true");
     }
   })

--- a/app/assets/stylesheets/3-atoms/_buttons.scss
+++ b/app/assets/stylesheets/3-atoms/_buttons.scss
@@ -34,6 +34,9 @@
 			background-color: lighten(red, 10%);
 		}
 	}
+	&#bulk_delete[aria-disabled=true] {
+		opacity: 0.5;
+	}
 }
 
 #contact-us-popup .button {

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -4,6 +4,8 @@
     <li><%= link_to @project.parent.title, project_path(@project.parent) %></li>
   <% end %>
 
+  <div class="number-of-stories-selected"></div>
+
   <table class="project-table">
     <thead class="project-table__header">
       <tr class="project-table__row project-table__row--header">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -4,8 +4,6 @@
     <li><%= link_to @project.parent.title, project_path(@project.parent) %></li>
   <% end %>
 
-  <div class="number-of-stories-selected"></div>
-
   <table class="project-table">
     <thead class="project-table__header">
       <tr class="project-table__row project-table__row--header">
@@ -14,7 +12,7 @@
         <th class="project-table__cell">Worst Estimate</th>
         <th class="project-table__cell">
           <%= link_to "Add a Story", new_project_story_path(@project.id), class: "button magenta"  %>
-          <button id="bulk_delete" class="button magenta">Bulk Delete</button>
+          <button id="bulk_delete" class="button magenta" aria-disabled="true">Bulk Delete</button>
         </th>
       </tr>
     </thead>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -4,8 +4,6 @@
     <li><%= link_to @project.parent.title, project_path(@project.parent) %></li>
   <% end %>
 
-  <div class="number-of-stories-selected"></div>
-
   <table class="project-table">
     <thead class="project-table__header">
       <tr class="project-table__row project-table__row--header">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -12,7 +12,7 @@
         <th class="project-table__cell">Worst Estimate</th>
         <th class="project-table__cell">
           <%= link_to "Add a Story", new_project_story_path(@project.id), class: "button magenta"  %>
-          <button id="bulk_delete" class="button magenta" aria-disabled="true">Bulk Delete</button>
+          <button id="bulk_delete" class="button magenta" aria-disabled="true" disabled>Bulk Delete</button>
         </th>
       </tr>
     </thead>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -4,6 +4,8 @@
     <li><%= link_to @project.parent.title, project_path(@project.parent) %></li>
   <% end %>
 
+  <div class="number-of-stories-selected"></div>
+
   <table class="project-table">
     <thead class="project-table__header">
       <tr class="project-table__row project-table__row--header">
@@ -12,7 +14,7 @@
         <th class="project-table__cell">Worst Estimate</th>
         <th class="project-table__cell">
           <%= link_to "Add a Story", new_project_story_path(@project.id), class: "button magenta"  %>
-          <button id="bulk_delete" class="button magenta">Delete</button>
+          <button id="bulk_delete" class="button magenta">Bulk Delete</button>
         </th>
       </tr>
     </thead>

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe 'managing stories', js: true do
   it "does not allow me to bulk delete stories when there are none selected" do
     visit project_path(id: project.id)
     expect(page).to have_selector("#bulk_delete[aria-disabled='true']")
+    expect(page).to have_selector("#bulk_delete[disabled]")
   end
 
   it "allows me to bulk delete stories when one or more stories are selected" do
@@ -55,6 +56,7 @@ RSpec.describe 'managing stories', js: true do
 
     within("#story_#{story.id}") {check(option: "#{story.id}")}
     expect(page).to have_no_selector("#bulk_delete[aria-disabled='true']")
+    expect(page).to have_no_selector("#bulk_delete[disabled]")
     expect(page).to have_button("Bulk Delete (1 Story)")
     click_button("Bulk Delete (1 Story)")
     expect(Story.count).to eq 0

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -44,4 +44,19 @@ RSpec.describe 'managing stories', js: true do
     find("p", text: "You don't have any stories yet.")
     expect(Story.count).to eq 0
   end
+
+  it "does not allow me to bulk delete stories when there are none selected" do
+    visit project_path(id: project.id)
+    expect(page).to have_selector("#bulk_delete[aria-disabled='true']")
+  end
+
+  it "allows me to bulk delete stories when one or more stories are selected" do
+    visit project_path(id: project.id)
+
+    within("#story_#{story.id}") {check(option: "#{story.id}")}
+    expect(page).to have_no_selector("#bulk_delete[aria-disabled='true']")
+    expect(page).to have_button("Bulk Delete (1 Story)")
+    click_button("Bulk Delete (1 Story)")
+    expect(Story.count).to eq 0
+  end
 end


### PR DESCRIPTION
**Description:**

This PR _Closes #30_.

<s>I decided to do two things for this feature: 

1. I renamed the magenta ‘Delete’ button to “Bulk Delete”, because I found it confusing to have two buttons named ‘Delete’.
2. I did some research about disabling the ‘Bulk Delete’ button when no stories are selected, but after reading that disabled buttons are bad for accessibility (particularly https://axesslab.com/disabled-buttons-suck/), I decided to keep the button enabled, and instead added an alert that tells the user to select one or more stories. You can see a video below:</s>

As discussed below, I renamed the magenta ‘Delete Button’ to ‘Bulk Delete’, and made it lighter/disabled it until 1 or more stories are selected. When 1 or more stories are selected, the number of stories are included in the button text.

## Before:
Initial state:
<img width="988" alt="Screen Shot 2021-06-02 at 12 12 28 PM" src="https://user-images.githubusercontent.com/6892410/120515502-5c8d2300-c39c-11eb-860f-a1e0036443d6.png">
When a story is selected:
<img width="988" alt="Screen Shot 2021-06-02 at 12 12 42 PM" src="https://user-images.githubusercontent.com/6892410/120516084-f8b72a00-c39c-11eb-8443-d24243fc4f21.png">

## After:
Initial state:
<img width="988" alt="Screen Shot 2021-06-02 at 12 07 41 PM" src="https://user-images.githubusercontent.com/6892410/120515563-6a42a880-c39c-11eb-9d1e-6662cec09dc7.png">

When a story is selected:
<img width="988" alt="Screen Shot 2021-06-02 at 12 08 20 PM" src="https://user-images.githubusercontent.com/6892410/120515577-6d3d9900-c39c-11eb-9c57-ae27198af2fe.png">


The tests are currently failing due to the Mimemagic 0.3.5 dependency, which is updated in this commit: _6e5eb49_. 

Please let me know if you have any suggestions.

I will abide by the [code of conduct](https://github.com/fastruby/points/CODE_OF_CONDUCT.md).
