### PR TITLE
Feature/add action plan prefix

### DIFF
--- a/app/assets/javascripts/action_plan.js
+++ b/app/assets/javascripts/action_plan.js
@@ -2,9 +2,8 @@ document.addEventListener("turbolinks:load", function() {
   $("input[name='action-plan_prefix']").keyup(function(event) {
     const prefix = event.target.value.trim();
 
-    $("h3.action-plan_heading").each(function(index) {
-      $(this).children("span").remove();
-      $(this).prepend(`<span>${prefix}${prefix == "" ? "" : index + 1} </span>`);
+    $("h3.action-plan_heading > span").each(function(index) {
+      $(this).text(`${prefix}${prefix == "" ? "" : index + 1 } `);
     });
   });
 });

--- a/app/assets/javascripts/action_plan.js
+++ b/app/assets/javascripts/action_plan.js
@@ -4,7 +4,7 @@ document.addEventListener("turbolinks:load", function() {
 
     $("h3.action-plan_heading > span").each(function(index) {
       const suffix = prefix.length === 0 ? "" : `${index+1}`
-      $(this).text(`${prefix}${suffix} `)
+      $(this).text(`${prefix}.${suffix} `)
     })
   })
 })

--- a/app/assets/javascripts/action_plan.js
+++ b/app/assets/javascripts/action_plan.js
@@ -1,9 +1,10 @@
 document.addEventListener("turbolinks:load", function() {
   $("#action-plan-prefix").keyup(function(event) {
-    const prefix = event.target.value.trim();
+    const prefix = event.target.value.trim()
 
     $("h3.action-plan_heading > span").each(function(index) {
-      $(this).text(`${prefix}${prefix === "" ? "" : index + 1 } `);
-    });
-  });
-});
+      const suffix = prefix.length === 0 ? "" : `${index+1}`
+      $(this).text(`${prefix}${suffix} `)
+    })
+  })
+})

--- a/app/assets/javascripts/action_plan.js
+++ b/app/assets/javascripts/action_plan.js
@@ -6,7 +6,7 @@ document.addEventListener("turbolinks:load", function() {
       let prevHeader = $(this).text();
       prevHeader = prevHeader.substring(prevHeader.indexOf(" ") + 1);
 
-      $(this).text(`${prefix}.${index + 1} ${prevHeader}`);
-    })
+      $(this).text(`${prefix}${prefix.length > 1 ? index + 1 : ""} ${prevHeader}`);
+    });
   });
 });

--- a/app/assets/javascripts/action_plan.js
+++ b/app/assets/javascripts/action_plan.js
@@ -1,10 +1,10 @@
 document.addEventListener("turbolinks:load", function() {
   $("input[name='action-plan_prefix']").keyup(function(event) {
-    let prefix = event.target.value;
+    const prefix = event.target.value.trim();
 
     $("h3.action-plan_heading").each(function(index) {
       $(this).children("span").remove();
-      $(this).prepend(`<span>${prefix}${prefix.trim() == "" ? "" : index + 1} </span>`);
+      $(this).prepend(`<span>${prefix}${prefix == "" ? "" : index + 1} </span>`);
     });
   });
 });

--- a/app/assets/javascripts/action_plan.js
+++ b/app/assets/javascripts/action_plan.js
@@ -3,10 +3,8 @@ document.addEventListener("turbolinks:load", function() {
     let prefix = event.target.value;
 
     $("h3.action-plan_heading").each(function(index) {
-      let prevHeader = $(this).text();
-      prevHeader = prevHeader.substring(prevHeader.indexOf(" ") + 1);
-
-      $(this).text(`${prefix}${prefix.length > 1 ? index + 1 : ""} ${prevHeader}`);
+      $(this).children("span").remove();
+      $(this).prepend(`<span>${prefix}${prefix.trim() == "" ? "" : index + 1} </span>`);
     });
   });
 });

--- a/app/assets/javascripts/action_plan.js
+++ b/app/assets/javascripts/action_plan.js
@@ -1,0 +1,12 @@
+document.addEventListener("turbolinks:load", function() {
+  $("input[name='action-plan_prefix']").keyup(function(event) {
+    let prefix = event.target.value;
+
+    $("h3.action-plan_heading").each(function(index) {
+      let prevHeader = $(this).text();
+      prevHeader = prevHeader.substring(prevHeader.indexOf(" ") + 1);
+
+      $(this).text(`${prefix}.${index + 1} ${prevHeader}`);
+    })
+  });
+});

--- a/app/assets/javascripts/action_plan.js
+++ b/app/assets/javascripts/action_plan.js
@@ -1,5 +1,5 @@
 document.addEventListener("turbolinks:load", function() {
-  $("input[name='action-plan_prefix']").keyup(function(event) {
+  $("input[name='action-plan-prefix']").keyup(function(event) {
     const prefix = event.target.value.trim();
 
     $("h3.action-plan_heading > span").each(function(index) {

--- a/app/assets/javascripts/action_plan.js
+++ b/app/assets/javascripts/action_plan.js
@@ -1,5 +1,5 @@
 document.addEventListener("turbolinks:load", function() {
-  $("input[name='action-plan-prefix']").keyup(function(event) {
+  $("#action-plan-prefix").keyup(function(event) {
     const prefix = event.target.value.trim();
 
     $("h3.action-plan_heading > span").each(function(index) {

--- a/app/assets/javascripts/action_plan.js
+++ b/app/assets/javascripts/action_plan.js
@@ -3,7 +3,7 @@ document.addEventListener("turbolinks:load", function() {
     const prefix = event.target.value.trim();
 
     $("h3.action-plan_heading > span").each(function(index) {
-      $(this).text(`${prefix}${prefix == "" ? "" : index + 1 } `);
+      $(this).text(`${prefix}${prefix === "" ? "" : index + 1 } `);
     });
   });
 });

--- a/app/assets/javascripts/action_plan.js
+++ b/app/assets/javascripts/action_plan.js
@@ -3,8 +3,8 @@ document.addEventListener("turbolinks:load", function() {
     const prefix = event.target.value.trim()
 
     $("h3.action-plan_heading > span").each(function(index) {
-      const suffix = prefix.length === 0 ? "" : `${index+1}`
-      $(this).text(`${prefix}.${suffix} `)
+      const suffix = prefix.length === 0 ? "" : `.${index+1}`
+      $(this).text(`${prefix}${suffix} `)
     })
   })
 })

--- a/app/views/action_plans/show.html.erb
+++ b/app/views/action_plans/show.html.erb
@@ -3,8 +3,14 @@
 
   <div id="action-plan">
     <h2>Action Plan</h2>
+
+    <label for="action-plan_prefix">
+      Enter Prefix
+      <input name="action-plan_prefix" type="text">
+    </label>
+
     <% @project_stories.each do |story| %>
-      <h3><%= story.title %></h3>
+      <h3 class="action-plan_heading"><%= story.title %></h3>
       <%= markdown(story.description) %>
     <% end %>
   </div>

--- a/app/views/action_plans/show.html.erb
+++ b/app/views/action_plans/show.html.erb
@@ -10,7 +10,7 @@
     </label>
 
     <% @project_stories.each do |story| %>
-      <h3 class="action-plan_heading"><%= story.title %></h3>
+      <h3 class="action-plan_heading"><span></span><%= story.title %></h3>
       <%= markdown(story.description) %>
     <% end %>
   </div>

--- a/app/views/action_plans/show.html.erb
+++ b/app/views/action_plans/show.html.erb
@@ -4,9 +4,9 @@
   <div id="action-plan">
     <h2>Action Plan</h2>
 
-    <label for="action-plan_prefix">
+    <label for="action-plan-prefix">
       Enter Prefix
-      <input name="action-plan_prefix" type="text">
+      <input id="action-plan-prefix" name="action-plan-prefix" type="text">
     </label>
 
     <% @project_stories.each do |story| %>

--- a/spec/features/action_plan_generate_spec.rb
+++ b/spec/features/action_plan_generate_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "generating an action plan" do
+RSpec.describe "generating an action plan", js: true do
   let(:admin_user) { FactoryBot.create(:user) }
   let(:project) do
     FactoryBot.create(:project).tap do |project|
@@ -14,9 +14,17 @@ RSpec.describe "generating an action plan" do
   it "generates copy pasteable report" do
     visit project_path(project)
     click_link "Generate Action Plan"
+
+    # Check that content is there
     expect(page).to have_selector("h1", text: project.title)
     expect(page).to have_selector("h2", text: "Action Plan")
-    expect(page.all("#action-plan h3").map(&:text)).to eq(["First Story", "Second Story"])
+    expect(page).to have_selector("input[name='action-plan_prefix']")
+    expect(page).to have_selector("h3.action-plan_heading > span", visible: false)
+    expect(page.all("#action-plan h3").map(&:text)).to eq(["FIRST STORY", "SECOND STORY"])
     expect(page.all("#action-plan p").map(&:text)).to eq(["First", "Second"])
+
+    # Set prefix
+    page.fill_in "action-plan_prefix", with: "3.2."
+    expect(page.all("h3.action-plan_heading > span").map(&:text)).to eq(["3.2.1", "3.2.2"])
   end
 end

--- a/spec/features/action_plan_generate_spec.rb
+++ b/spec/features/action_plan_generate_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "generating an action plan", js: true do
     expect(page.all("#action-plan p").map(&:text)).to eq(["First", "Second"])
 
     # Set prefix
-    page.fill_in "action-plan-prefix", with: "3.2."
+    page.fill_in "action-plan-prefix", with: "3.2"
     expect(page.all("h3.action-plan_heading > span").map(&:text)).to eq(["3.2.1", "3.2.2"])
   end
 end

--- a/spec/features/action_plan_generate_spec.rb
+++ b/spec/features/action_plan_generate_spec.rb
@@ -26,5 +26,9 @@ RSpec.describe "generating an action plan", js: true do
     # Set prefix
     page.fill_in "action-plan-prefix", with: "3.2"
     expect(page.all("h3.action-plan_heading > span").map(&:text)).to eq(["3.2.1", "3.2.2"])
+
+    # Ensure that dot is not there when prefix input is empty
+    page.fill_in "action-plan-prefix", with: " "
+    expect(page.all("#action-plan h3").map(&:text)).to eq(["FIRST STORY", "SECOND STORY"])
   end
 end

--- a/spec/features/action_plan_generate_spec.rb
+++ b/spec/features/action_plan_generate_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe "generating an action plan", js: true do
     # Check that content is there
     expect(page).to have_selector("h1", text: project.title)
     expect(page).to have_selector("h2", text: "Action Plan")
-    expect(page).to have_selector("input[name='action-plan_prefix']")
+    expect(page).to have_selector("input[name='action-plan-prefix']")
     expect(page).to have_selector("h3.action-plan_heading > span", visible: false)
     expect(page.all("#action-plan h3").map(&:text)).to eq(["FIRST STORY", "SECOND STORY"])
     expect(page.all("#action-plan p").map(&:text)).to eq(["First", "Second"])
 
     # Set prefix
-    page.fill_in "action-plan_prefix", with: "3.2."
+    page.fill_in "action-plan-prefix", with: "3.2."
     expect(page.all("h3.action-plan_heading > span").map(&:text)).to eq(["3.2.1", "3.2.2"])
   end
 end


### PR DESCRIPTION
**Description:**

This PR closes _#23_ . It adds an input that adds a prefix to each item in the action plan.

Before screenshot: 
<img width="1118" alt="Screen Shot 2021-06-22 at 4 19 55 PM" src="https://user-images.githubusercontent.com/6892410/122993840-c84c2580-d375-11eb-8bc4-e839741b03d4.png">

After video:

https://user-images.githubusercontent.com/6892410/122994011-f92c5a80-d375-11eb-84ee-d07d6049f10b.mov

I tested this manually in Chrome, Firefox, and Safari.

I will abide by the [code of conduct](https://github.com/fastruby/points/CODE_OF_CONDUCT.md).
