### PR TITLE
Add before action filter to handle proxy requests

### DIFF
--- a/app/controllers/callbacks_controller.rb
+++ b/app/controllers/callbacks_controller.rb
@@ -1,6 +1,8 @@
 require "open-uri"
 
 class CallbacksController < Devise::OmniauthCallbacksController
+  before_action :handle_proxy_requests
+
   def github
     username = request.env["omniauth.auth"]["extra"]["raw_info"]["login"]
 
@@ -17,6 +19,13 @@ class CallbacksController < Devise::OmniauthCallbacksController
   end
 
   private
+
+  def handle_proxy_requests
+    if params['proxy_to']
+      path = request.fullpath.gsub(/proxy_to=[^&]*&/, '')
+      redirect_to "#{params['proxy_to']}#{path}"
+    end
+  end
 
   def organization_members
     @organization_members ||= begin

--- a/spec/controllers/callbacks_controller_spec.rb
+++ b/spec/controllers/callbacks_controller_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe CallbacksController, type: :controller do
+  before do
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+    @request.env["omniauth.auth"] =
+      OmniAuth.config.mock_auth[:github] =
+        OmniAuth::AuthHash.new({"extra" => OmniAuth::AuthHash.new({
+          "raw_info" => OmniAuth::AuthHash.new({"login" => "mockuser"})
+        })})
+  end
+
+  describe "#github" do
+    context "with a proxy_to param" do
+      it "redirects to provided host" do
+        get :github, params: {proxy_to: "http://example.com", code: "code", state: "state"}
+        expect(subject).to redirect_to("http://example.com/users/auth/github/callback?code=code&state=state")
+      end
+    end
+
+    context "without a proxy_to param" do
+      it "redirects user to sign in" do
+        CallbacksController.any_instance.stub(:organization_members).and_return([])
+        get :github, params: {code: "code", state: "state"}
+        expect(subject).to redirect_to("http://test.host/users/sign_in")
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Description:**

To enable authentication on preview apps we need to do 2 things.

1. A way for auth callbacks to be directed to a preview app
2. A way to provide the preview app url (since they are dynamic)

This PR adds 1. We can proceed to add 2 and only test that 2 works once 1 is deployed.

`The new controller filter will accept a proxy_to param and forward callback requests to the provided domain.`
Rspec specs confirm that this works.

I will abide by the [code of conduct](https://github.com/fastruby/points/CODE_OF_CONDUCT.md).
