### PR TITLE
Updates alert to alert-success

### DIFF
--- a/app/assets/stylesheets/3-atoms/_forms.scss
+++ b/app/assets/stylesheets/3-atoms/_forms.scss
@@ -54,7 +54,7 @@ input, textarea {
   }
 }
 
-.alert {
+.alert-success {
   color: black;
   background-color: #D9F1F1;
   border-color: #D9F1F1;


### PR DESCRIPTION
**Description:**

This PR closes #57.

While using Points, I noticed that alerts are always a light blue-green color, regardless if the alert represents success or danger. I noticed that the `alert` class was overwritten later in the stylesheet than Bootstrap's contextual classes (`alert-success`, `alert-danger`), which means that because of the CSS cascade, Bootstrap's contextual classes do not display as expected. Instead of overwriting the `alert` class, I just changed that declaration to overwrite the styling for `alert-success` so that the other classes (particularly `alert-danger`) work as expected. 😸 

<img width="1161" alt="Screen Shot 2021-07-19 at 12 06 01 PM" src="https://user-images.githubusercontent.com/6892410/126193172-31e746df-9fa8-4b0f-adf0-9f715831b088.png">

I will abide by the [code of conduct](https://github.com/fastruby/points/CODE_OF_CONDUCT.md).
