### PR TITLE
Updates Modal's event loading so that it always fires

### DIFF
--- a/app/assets/javascripts/modal.js
+++ b/app/assets/javascripts/modal.js
@@ -1,5 +1,5 @@
 let modal = false
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener("turbolinks:load", () => {
   modal = document.querySelector(".modal")
 })
 

--- a/spec/features/modal_displays_always_spec.rb
+++ b/spec/features/modal_displays_always_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "managing estimates" do
+  let(:user) { FactoryBot.create(:user) }
+  let(:project) { FactoryBot.create(:project) }
+  let!(:story) { FactoryBot.create(:story, project: project) }
+
+  before do
+    login_as(user, scope: :user)
+  end
+
+  it "allows me to click on the modal twice in a row", js: true do
+    visit project_path(id: project.id)
+    click_link "Add Estimate"
+    expect(page).to have_text("New Estimate")
+    expect(page).to have_content(story.description)
+    find(".close").click()
+
+
+    click_link "points app"
+    find(".project-card:nth-of-type(1)").click()
+    click_link "Add Estimate"
+    expect(page).to have_text("New Estimate")
+    expect(page).to have_content(story.description)
+  end
+end


### PR DESCRIPTION
**Description:**

Closes #65. 

From what I’ve read from the Turbolinks documentation, we should be using the `turbo links:load` event in place of `DOMContentLoaded` so that the JavaScript is executed on every page change. I think the default behavior with Turbolinks is that `DOMContentLoaded` fires only in response to the initial page load, not after any subsequent page changes, so that’s why the modal only pops up intermittently. (For reference: https://github.com/turbolinks/turbolinks#installing-javascript-behavior)

I ended up testing this manually (going from page to page, pressing the ‘Add Estimate’ button to see if it appears.) If anyone can point me towards some ideas towards testing this through a spec, I would be happy to hear it. 

I will abide by the [code of conduct](https://github.com/fastruby/points/CODE_OF_CONDUCT.md).
