### PR TITLE
Fixes code block overflow issue in estimation modal

### DIFF
--- a/app/assets/stylesheets/stories.scss
+++ b/app/assets/stylesheets/stories.scss
@@ -28,3 +28,11 @@
   font-size: 1.5rem;
   margin-bottom: .5rem;
 }
+
+.modal .story-description p {
+  overflow: auto;
+}
+
+.modal p {
+  padding-bottom: 1.3em;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,6 @@ module ApplicationHelper
   OPTIONS = {
     filter_html: true,
     link_attributes: {rel: "nofollow", target: "_blank"},
-    fenced_code_blocks: true,
     no_intra_emphasis: true
   }.freeze
 


### PR DESCRIPTION
**Description:**

Fixes #67 and also remove the `fenced_code_block` key in the `OPTIONS` hash in `application_helper.rb`, since it was being passed into the wrong constructor.

Code blocks made with triple backticks will now exhibit themselves properly, not overflowing the modal but adding horizontal scrolling if needed

![bug_fix](https://user-images.githubusercontent.com/14188887/130070178-9f20d144-0912-4efc-a63a-93092465a0f0.gif)

I will abide by the [code of conduct](https://github.com/fastruby/points/CODE_OF_CONDUCT.md).
