### PR TITLE
Update the titles on some pages to be sticky. 

### DIFF
--- a/app/assets/stylesheets/1-utilities/_basic.scss
+++ b/app/assets/stylesheets/1-utilities/_basic.scss
@@ -2,13 +2,13 @@
 /* ========================== */
 
 * {
-	margin: 0;
-	padding: 0;
-	box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
-main{
-	min-height: calc(100vh - 160px);
-	padding: 100px 0;
+main {
+  min-height: calc(100vh - 160px);
+  padding: 60px 0;
 }
 ::selection {
   background: $orange;
@@ -23,5 +23,5 @@ textarea {
   resize: vertical;
 }
 .hidden {
-	display:none;
+  display: none;
 }

--- a/app/assets/stylesheets/2-quarks/_custom_typography.scss
+++ b/app/assets/stylesheets/2-quarks/_custom_typography.scss
@@ -1,12 +1,11 @@
-
 // Typography mixins:
 @mixin font-open-sans-light {
-	font-family: $font-open-sans;
-	font-weight: 300;
+  font-family: $font-open-sans;
+  font-weight: 300;
 }
 @mixin font-open-sans-normal {
-	font-family: $font-open-sans;
-	font-weight: 400;
+  font-family: $font-open-sans;
+  font-weight: 400;
 }
 @mixin font-open-sans-bold {
   font-family: $font-open-sans;
@@ -18,46 +17,46 @@
 }
 
 @mixin font-maven {
-	font-family: $font-maven;
-	font-weight: 400;
+  font-family: $font-maven;
+  font-weight: 400;
 }
 
 // Styles:
 body {
-	@include font-open-sans-light;
-	background-color: $white;
+  @include font-open-sans-light;
+  background-color: $white;
   color: $black;
   font-size: 13px;
   line-height: 18px;
 }
 h3 {
-	font-size: 2.41176470588235em; // 41px
-	letter-spacing: 1px;
-	margin: .5em 0;
+  font-size: 2.41176470588235em; // 41px
+  letter-spacing: 1px;
+  margin: 0.5em 0;
   @media screen and (max-width: $breakpoint_768px) {
-		font-size: 1.5em;
+    font-size: 1.5em;
   }
   &:first-child {
-  	margin-top: 0;
+    margin-top: 0;
   }
 }
 h4 {
-	@include font-open-sans-bold;
-	font-size: 1.5em; // 27px
-	letter-spacing: .04em;
+  @include font-open-sans-bold;
+  font-size: 1.5em; // 27px
+  letter-spacing: 0.04em;
   @media screen and (max-width: $breakpoint_768px) {
-		font-size: 1.2em;
+    font-size: 1.2em;
   }
 }
 
 .values h4 {
-	text-transform: uppercase;
+  text-transform: uppercase;
 }
 
 .ombulabs-brand {
   text-transform: uppercase;
   @include font-lato-bold;
-  font-size: .85em;
+  font-size: 0.85em;
 }
 
 .dashboard-title {
@@ -67,6 +66,25 @@ h4 {
   font-size: 35px;
   font-weight: 300;
   line-height: 1.2em;
+}
+
+.dashboard-title-report {
+  width: 100%;
+  position: sticky;
+  top: 53px;
+  background: white;
+  text-align: left;
+  font-size: 35px;
+  font-weight: 300;
+  line-height: 100px;
+  z-index: 1;
+}
+
+.fixed-header {
+  position: sticky;
+  top: 148px;
+  background: white;
+  z-index: 1;
 }
 
 .new-edit-title {

--- a/app/assets/stylesheets/3-atoms/_forms.scss
+++ b/app/assets/stylesheets/3-atoms/_forms.scss
@@ -1,35 +1,42 @@
 label {
-	@include font-open-sans-normal;
-	margin-top: 1em;
-	margin-bottom: .2em;
-	display: block;
+  @include font-open-sans-normal;
+  margin-top: 1em;
+  margin-bottom: 0.2em;
+  display: block;
 }
-input, textarea {
-	display: block;
-	border: none;
-	background: #fff;
-	padding: 10px;
-	width: 100%;
-	border-radius: 2px;
-	font-size: 1em;
-	border: 1px solid $orange;
-	&:focus{
-		outline: none;
-		border: 1px solid $green;
-	}
+input,
+textarea {
+  display: block;
+  border: none;
+  background: #fff;
+  padding: 10px;
+  width: 100%;
+  border-radius: 2px;
+  font-size: 1em;
+  border: 1px solid $orange;
+  &:focus {
+    outline: none;
+    border: 1px solid $green;
+  }
 }
+input[type="checkbox"] {
+  display: inline;
+  width: auto;
+  margin-right: 5px;
+}
+
 .form-error {
-	background: $orange;
-	padding: 10px 20px;
-	margin-top: 2em;
-	margin-bottom: 2em;
-	border-radius: 24px;
+  background: $orange;
+  padding: 10px 20px;
+  margin-top: 2em;
+  margin-bottom: 2em;
+  border-radius: 24px;
 }
 .form-success {
-	color: #57CE81;
-	@include font-open-sans-normal;
-	font-size: 1.2em;
-	padding-top: 20px;
+  color: #57ce81;
+  @include font-open-sans-normal;
+  font-size: 1.2em;
+  padding-top: 20px;
 }
 #error_explanation {
   width: 450px;
@@ -56,11 +63,12 @@ input, textarea {
 
 .alert-success {
   color: black;
-  background-color: #D9F1F1;
-  border-color: #D9F1F1;
+  background-color: #d9f1f1;
+  border-color: #d9f1f1;
   font-size: 12px;
 }
 
-.field, .actions {
-	margin-bottom: 10px;
+.field,
+.actions {
+  margin-bottom: 10px;
 }

--- a/app/assets/stylesheets/4-molecules/_tables.scss
+++ b/app/assets/stylesheets/4-molecules/_tables.scss
@@ -1,6 +1,6 @@
 .project-table {
   display: grid;
-  padding: 50px 0;
+  padding: 0 0 50px;
   &__header {
     position: sticky;
     background: #ffffff;

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,11 +1,11 @@
 <div class="container">
-  <h1 class="dashboard-title"><%= @project.title %></h1>
+  <h1 class="dashboard-title-report"><%= @project.title %></h1>
   <% if @project.parent %>
     <li><%= link_to @project.parent.title, project_path(@project.parent) %></li>
   <% end %>
 
   <table class="project-table">
-    <thead class="project-table__header">
+    <thead class="fixed-header">
       <tr class="project-table__row project-table__row--header">
         <th class="project-table__cell">Story Title</th>
         <th class="project-table__cell">Best Estimate</th>
@@ -22,10 +22,8 @@
         <% @stories.each do | story | %>
           <tr class="project-table__row project-table__row--story" id="<%= dom_id(story)%>" >
             <td class="project-table__cell">
-              <div class="checkbox">
-                <input type="checkbox" name="stories[]" value=<%= story.id %>>
-                <%= link_to story.title, [story.project, story] %>
-              </div>
+              <input type="checkbox" name="stories[]" value=<%= story.id %>>
+              <%= link_to story.title, [story.project, story] %>
             </td>
             <td class="project-table__cell"><%= story.estimates.where(user: current_user)&.first&.best_case_points %></td>
             <td class="project-table__cell"><%= story.estimates.where(user: current_user)&.first&.worst_case_points %></td>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,9 +1,9 @@
 <div class="container">
-  <h1 class="dashboard-title">Project Reports</h1>
+  <h1 class="dashboard-title-report">Project Reports</h1>
 
   <table class="project-table">
 
-    <thead>
+    <thead class="fixed-header">
       <tr class="project-table__row project-table__row--project-reports project-table__row--header">
         <td class="project-table__cell">Project</td>
         <td class="project-table__cell">Report</td>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,8 +1,8 @@
 <div class="container">
-  <h1 class="dashboard-title"><%= @project.title %> Report</h1>
+  <h1 class="dashboard-title-report"><%= @project.title %> Report</h1>
 
   <table class="project-table">
-    <thead>
+    <thead class="fixed-header">
       <tr class="project-table__row project-table__row--reports project-table__row--header">
         <td class="project-table__cell">Story Title</td>
         <% @users.each do |user| %>
@@ -20,7 +20,7 @@
       </tr>
     </thead>
 
-    <tbody id="stories">
+    <tbody id="report-stories">
       <% if @stories.present? %>
         <% @stories.each do | story | %>
         <tr class="project-table__row project-table__row--reports project-table__row--story">
@@ -42,7 +42,7 @@
       <% else %>
           <p> This user doesn't have any stories yet. </p>
       <% end %>
-      
+
     </tbody>
     <tfoot>
       <tr class="project-table__row project-table__row--reports project-table__row--footer">


### PR DESCRIPTION
Closes #68 

**Description:**

This PR makes it so that the title on most of the pages is sticky and therefor easier to remember what are doing if you are scrolling a lot. I also had to update the table headers on some of the pages to be fixed with position: sticky as well. To be able to achieve this on the estimates page it was necessary to move the checkboxes back inside the table. 
Pages worked on:
Estimates page
Report show page
Report index page

Scrolled on report page:
![Screen Shot 2021-09-28 at 10 13 16 PM](https://user-images.githubusercontent.com/28625558/135192204-eddd5e10-fa3e-45bf-8016-d2fdeb96fc09.png)

Scrolled on Estimates Page:
![Screen Shot 2021-09-28 at 10 21 51 PM](https://user-images.githubusercontent.com/28625558/135192421-8231ceb5-6af4-405e-a129-f6e6be03588d.png)




I will abide by the [code of conduct](https://github.com/fastruby/points/CODE_OF_CONDUCT.md).
