### PR TITLE
Bugfix/update estimate totals

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ end
 gem "jquery-ui-rails", "~> 5.0", ">= 5.0.5"
 gem "acts_as_list"
 
-gem 'mimemagic', '~> 0.3.8'
+gem "mimemagic", "~> 0.3.8"
 
 gem "omniauth-github", "~> 2.0.0"
 gem "omniauth-rails_csrf_protection"

--- a/app/controllers/callbacks_controller.rb
+++ b/app/controllers/callbacks_controller.rb
@@ -21,9 +21,9 @@ class CallbacksController < Devise::OmniauthCallbacksController
   private
 
   def handle_proxy_requests
-    if params['proxy_to']
-      path = request.fullpath.gsub(/proxy_to=[^&]*&/, '')
-      redirect_to "#{params['proxy_to']}#{path}"
+    if params["proxy_to"]
+      path = request.fullpath.gsub(/proxy_to=[^&]*&/, "")
+      redirect_to "#{params["proxy_to"]}#{path}"
     end
   end
 

--- a/app/controllers/estimates_controller.rb
+++ b/app/controllers/estimates_controller.rb
@@ -32,6 +32,7 @@ class EstimatesController < ApplicationController
 
   def update
     @estimate = Estimate.find(params[:id])
+    @project = Project.find(params[:project_id])
     params["estimate"]["user_id"] = current_user.id
     updated = @estimate.update(estimate_params)
     respond_to do |format|

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -34,7 +34,7 @@ class ProjectsController < ApplicationController
 
     original.stories.each { |x| duplicate.stories.create(x.dup.attributes) }
 
-    flash[:success] = 'Project created!'
+    flash[:success] = "Project created!"
     redirect_to "/projects/#{duplicate.id}"
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -37,7 +37,7 @@ class Project < ApplicationRecord
   end
 
   def archived?
-    status == "archived"  
+    status == "archived"
   end
 
   def toggle_archived!

--- a/app/views/estimates/_update_estimates.js.erb
+++ b/app/views/estimates/_update_estimates.js.erb
@@ -1,3 +1,7 @@
-const row = document.getElementById("story_<%= estimate.story_id %>")
+let row = document.getElementById("story_<%= estimate.story_id %>")
 row.children[1].innerText = "<%= j(estimate.best_case_points.to_s) %>"
 row.children[2].innerText = "<%= j(estimate.worst_case_points.to_s) %>"
+
+let totals_row = document.querySelector('.project-table tfoot tr')
+totals_row.children[1].innerText = "<%= j @project.best_estimate_sum_per_user(current_user) %>"
+totals_row.children[2].innerText = "<%= j @project.worst_estimate_sum_per_user(current_user) %>"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
-  config.ssl_options = {  redirect: { status: 301 } }
+  config.ssl_options = {redirect: {status: 301}}
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -24,14 +24,13 @@ RSpec.describe ProjectsController, type: :controller do
 
   describe "#index with archived params" do
     before do
-      get :index, params: { archived: true }
+      get :index, params: {archived: true}
     end
 
     it "shows me a list of all the archived projects" do
       expect(assigns(:projects)).to eq [archived_project]
     end
   end
-
 
   describe "#new" do
     it "redirects to the new page" do
@@ -145,40 +144,40 @@ RSpec.describe ProjectsController, type: :controller do
     end
   end
 
-  describe 'duplicate' do
-    context 'with a project' do
+  describe "duplicate" do
+    context "with a project" do
       before do
-        post :duplicate, params: { id: project.id }
+        post :duplicate, params: {id: project.id}
       end
 
-      it 'creates a duplicate project' do
+      it "creates a duplicate project" do
         expect(Project.last.title).to eq "Copy of #{project.title}"
       end
 
-      it 'redirects to new project' do
+      it "redirects to new project" do
         expect(response).to redirect_to "/projects/#{Project.last.id}"
       end
 
-      it 'adds a success message' do
+      it "adds a success message" do
         expect(flash[:success]).to be_present
       end
     end
 
-    context 'with stories' do
-      it 'creates a duplicate project with matching stories' do
-        story = project.stories.create({ title: 'Story 1' })
+    context "with stories" do
+      it "creates a duplicate project with matching stories" do
+        story = project.stories.create({title: "Story 1"})
 
-        post :duplicate, params: { id: project.id }
+        post :duplicate, params: {id: project.id}
 
         expect(Project.last.stories.first.id).not_to eq story.id
         expect(Project.last.stories.first.title).to eq story.title
       end
 
-      it 'creates stories without estimates' do
-        story = project.stories.create({ title: 'Story 1' })
-        story.estimates.create({ best_case_points: 1, worst_case_points: 3 })
+      it "creates stories without estimates" do
+        story = project.stories.create({title: "Story 1"})
+        story.estimates.create({best_case_points: 1, worst_case_points: 3})
 
-        post :duplicate, params: { id: project.id }
+        post :duplicate, params: {id: project.id}
 
         expect(Project.last.stories.first.estimates).to be_empty
       end

--- a/spec/features/modal_displays_always_spec.rb
+++ b/spec/features/modal_displays_always_spec.rb
@@ -14,11 +14,10 @@ RSpec.describe "managing estimates" do
     click_link "Add Estimate"
     expect(page).to have_text("New Estimate")
     expect(page).to have_content(story.description)
-    find(".close").click()
-
+    find(".close").click
 
     click_link "points app"
-    find(".project-card:nth-of-type(1)").click()
+    find(".project-card:nth-of-type(1)").click
     click_link "Add Estimate"
     expect(page).to have_text("New Estimate")
     expect(page).to have_content(story.description)

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe "managing projects" do
   let(:user) { FactoryBot.create(:user) }
   let(:project) { FactoryBot.create(:project) }
 
-
   before do
     login_as(user, scope: :user)
   end
@@ -42,7 +41,6 @@ RSpec.describe "managing projects" do
     click_link "Archive Project"
     expect(page).to have_content "Unarchive Project"
     expect(project.reload).to be_archived
-
   end
 
   it "allows me to delete a project" do

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "managing stories", js: true do
   it "allows me to bulk delete stories when one or more stories are selected" do
     visit project_path(id: project.id)
 
-    within("#story_#{story.id}") {check(option: "#{story.id}")}
+    within("#story_#{story.id}") { check(option: story.id.to_s) }
     expect(page).to have_no_selector("#bulk_delete[aria-disabled='true']")
     expect(page).to have_no_selector("#bulk_delete[disabled]")
     expect(page).to have_button("Bulk Delete (1 Story)")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe User, type: :model do
     describe ".from_omniauth" do
       let(:auth) do
         RecursiveOpenStruct.new(provider: "github",
-                                uid: "uuiidd11",
-                                info: {email: "testuser@email.com", name: "TestUser"})
+          uid: "uuiidd11",
+          info: {email: "testuser@email.com", name: "TestUser"})
       end
 
       it "creates a user" do


### PR DESCRIPTION
This PR _Closes #77 

**Description:**

The estimate totals are now getting updated on Adding/Editing estimates of stories.

Commits:
1. The first commit contains the actual bugfix code
2. Created the second commit for **Ruby Standard Style** changes made by running `standardrb --fix`.

Also fixed this Javascript console error: "Identifier `row` has already been declared" by making use of `let` instead of `const`

error reference:
![image](https://user-images.githubusercontent.com/17007613/135526145-22c31cd4-2d9d-4849-b736-5a8631c71e95.png)

I will abide by the [code of conduct](https://github.com/fastruby/points/CODE_OF_CONDUCT.md).