### PR TITLE
adds correct code of conduct link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -58,4 +58,4 @@ If the issue has an effect in the frontend, include any relevant screenshots and
 
 Include relevant log snippets or files here.
 
-**I will abide by the [code of conduct] (CODE_OF_CONDUCT.md)**
+**I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md)**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -44,4 +44,4 @@ Include any mockup idea related to the requested feature if it applies.
 
 If you have resources related to the implementation or research for this feature, add them here.
 
-**I will abide by the [code of conduct](CODE_OF_CONDUCT.md)**
+**I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md)**


### PR DESCRIPTION
**Description:**

Fixes the link to the code of conduct in both issue templates. Uses actual URL instead of just a link to the `.md` file.
Also fixes the spacing between the link text and URL in `ISSUE_TEMPLATE/bug_report.md`.

I will abide by the [code of conduct](https://github.com/fastruby/points/CODE_OF_CONDUCT.md).
