### PR TITLE
Prevent users interacting with other users' estimates

### DIFF
--- a/app/controllers/estimates_controller.rb
+++ b/app/controllers/estimates_controller.rb
@@ -8,12 +8,11 @@ class EstimatesController < ApplicationController
   end
 
   def edit
-    @estimate = Estimate.find(params[:id])
   end
 
   def create
-    params["estimate"]["user_id"] = current_user.id
-    @estimate = Estimate.new(estimate_params)
+    @estimate = current_user.estimates.build(estimate_params)
+    @estimate.story_id = params[:story_id]
 
     saved = @estimate.save
     respond_to do |format|
@@ -31,9 +30,7 @@ class EstimatesController < ApplicationController
   end
 
   def update
-    @estimate = Estimate.find(params[:id])
     @project = Project.find(params[:project_id])
-    params["estimate"]["user_id"] = current_user.id
     updated = @estimate.update(estimate_params)
     respond_to do |format|
       format.html do
@@ -65,10 +62,13 @@ class EstimatesController < ApplicationController
   end
 
   def find_estimate
-    @estimate = Estimate.find(params[:id])
+    @estimate = current_user.estimates.where(story_id: params[:story_id]).find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    flash[:error] = "Estimate not found"
+    redirect_to project_path(params[:project_id])
   end
 
   def estimate_params
-    params.require(:estimate).permit(:best_case_points, :worst_case_points, :user_id, :story_id)
+    params.require(:estimate).permit(:best_case_points, :worst_case_points)
   end
 end

--- a/app/models/estimate.rb
+++ b/app/models/estimate.rb
@@ -2,6 +2,8 @@ class Estimate < ApplicationRecord
   belongs_to :story
   belongs_to :user
 
+  validates :best_case_points, :worst_case_points, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
   validate :check_estimates
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
     :recoverable, :rememberable, :trackable, :validatable, :omniauthable
 
+  has_many :estimates
+
   def self.from_omniauth(auth)
     user_attributes = {
       email: auth.info.email,

--- a/app/views/estimates/_form.html.erb
+++ b/app/views/estimates/_form.html.erb
@@ -25,7 +25,6 @@
     </div>
   </div>
 
-  <%= f.hidden_field :story_id, value: params[:story_id] %>
   <div class="btn-group">
     <%= f.submit yield(:button_text), class: "button", id: "edit" %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
       patch :real_scores, on: :collection, to: "real_scores#update"
       patch :import, on: :collection
       get :export, on: :collection
-      resources :estimates
+      resources :estimates, except: [:index, :show]
     end
     resource :action_plan, only: [:show]
   end

--- a/spec/controllers/estimates_controller_spec.rb
+++ b/spec/controllers/estimates_controller_spec.rb
@@ -10,20 +10,19 @@ RSpec.describe EstimatesController, type: :controller do
 
   before do
     @request.env["devise.mapping"] = Devise.mappings[:user]
-    user = FactoryBot.create(:user)
     sign_in user
   end
 
   describe "#new" do
     it "redirects to the new page" do
-      get :new, params: {id: estimate.id, story_id: story.id, project_id: project.id, user_id: user.id}
+      get :new, params: {id: estimate.id, story_id: story.id, project_id: project.id}
       expect(response).to render_template :new
     end
   end
 
   describe "#edit" do
     before do
-      get :edit, params: {id: estimate.id, story_id: story.id, project_id: project.id, user_id: user.id}
+      get :edit, params: {id: estimate.id, story_id: story.id, project_id: project.id}
     end
 
     it "redirects to the edit page" do
@@ -35,24 +34,36 @@ RSpec.describe EstimatesController, type: :controller do
     end
   end
 
+  describe "#edit as other user" do
+    it "disallows editing another users' estimate" do
+      user2 = FactoryBot.create(:user)
+      estimate2 = FactoryBot.create(:estimate, story: story, user: user2)
+
+      get :edit, params: {id: estimate2.id, story_id: story.id, project_id: project.id}
+
+      expect(response).to redirect_to project_path(story.project)
+      expect(flash[:error]).to eq "Estimate not found"
+    end
+  end
+
   describe "#create" do
     context "with valid attributes" do
-      let(:valid_params) {
-        {best_case_points: 1, worst_case_points: 3, story_id: story.id}
+      let(:estimate_params) {
+        {best_case_points: 1, worst_case_points: 3}
       }
 
       it "creates a new estimate" do
         expect {
           post :create, params: {project_id: project.id,
                                  story_id: story.id,
-                                 estimate: valid_params}
+                                 estimate: estimate_params}
         }.to change(Estimate, :count).by(1)
       end
 
       it "redirects to the new estimate" do
         post :create, params: {story_id: story.id,
                                project_id: project.id,
-                               estimate: valid_params}
+                               estimate: estimate_params}
 
         expect(response).to redirect_to project_path(project.id)
       end
@@ -83,6 +94,16 @@ RSpec.describe EstimatesController, type: :controller do
         delete :destroy, params: {id: estimate.id, story_id: story.id, project_id: project.id}
       }.to change(Estimate, :count).by(-1)
     end
+
+    it "disallows destroying another users' estimate" do
+      user2 = FactoryBot.create(:user)
+      estimate2 = FactoryBot.create(:estimate, story: story, user: user2)
+
+      delete :destroy, params: {id: estimate2.id, story_id: story.id, project_id: project.id}
+
+      expect(response).to redirect_to project_path(story.project)
+      expect(flash[:error]).to eq "Estimate not found"
+    end
   end
 
   describe "#update" do
@@ -93,6 +114,19 @@ RSpec.describe EstimatesController, type: :controller do
                             estimate: {best_case_points: "7", worst_case_points: "10"}}
 
       expect(estimate.reload.best_case_points).to eq 7
+    end
+
+    it "disallows updating another users' estimate" do
+      user2 = FactoryBot.create(:user)
+      estimate2 = FactoryBot.create(:estimate, story: story, user: user2)
+
+      put :update, params: {id: estimate2.id,
+                            story_id: story.id,
+                            project_id: project.id,
+                            estimate: {best_case_points: "7", worst_case_points: "10"}}
+
+      expect(response).to redirect_to project_path(story.project)
+      expect(flash[:error]).to eq "Estimate not found"
     end
   end
 end


### PR DESCRIPTION
**Description:**

This PR fixes a security issue where a user could modify certain parameters in the url to view, edit, update, or destroy estimates made by another user.

I also fixed some things that appeared after changing the code (like the estimate validations were not right), I'll add comments on the diff

Closes #100 

I will abide by the [code of conduct](https://github.com/fastruby/points/CODE_OF_CONDUCT.md).
