### PR TITLE
Generate action plan with nested projects

### DIFF
--- a/app/assets/javascripts/action_plan.js
+++ b/app/assets/javascripts/action_plan.js
@@ -2,9 +2,9 @@ document.addEventListener("turbolinks:load", function() {
   $("#action-plan-prefix").keyup(function(event) {
     const prefix = event.target.value.trim()
 
-    $("h3.action-plan_heading > span").each(function(index) {
-      const suffix = prefix.length === 0 ? "" : `.${index+1}`
-      $(this).text(`${prefix}${suffix} `)
+    document.querySelectorAll(".action-plan_heading > span.index").forEach((el) => {
+      const suffix = prefix.length === 0 ? "" : `.${el.dataset.idx}`
+      el.innerText = `${prefix}${suffix} `
     })
   })
 })

--- a/app/assets/stylesheets/action_plans.scss
+++ b/app/assets/stylesheets/action_plans.scss
@@ -1,6 +1,16 @@
-
 .action_plans-controller {
   #action-plan {
     margin-bottom: 50px;
+  }
+  .action-plan_heading {
+    font-size: 16pt;
+    line-height: 1.2em;
+    margin: 0.2em auto;
+    text-transform: none;
+  }
+  .action-plan_heading ~ p {
+    font-size: 14pt;
+    line-height: 1.2em;
+    margin: 0.5em auto;
   }
 }

--- a/app/controllers/action_plans_controller.rb
+++ b/app/controllers/action_plans_controller.rb
@@ -4,5 +4,6 @@ class ActionPlansController < ApplicationController
   def show
     @project = Project.find(params[:project_id])
     @project_stories = @project.stories.order(:position)
+    @children = Project.where(parent_id: @project.id).includes(:stories).references(:stories).order("stories.position")
   end
 end

--- a/app/views/action_plans/show.html.erb
+++ b/app/views/action_plans/show.html.erb
@@ -9,9 +9,21 @@
       <input id="action-plan-prefix" name="action-plan-prefix" type="text">
     </label>
 
+    <% idx = 0 %>
     <% @project_stories.each do |story| %>
-      <h3 class="action-plan_heading"><span></span><%= story.title %></h3>
+      <% idx += 1 %>
+      <h3 class="action-plan_heading"><span class="index"  data-idx="<%= idx %>."></span><%= story.title %></h3>
       <%= markdown(story.description) %>
+    <% end %>
+
+    <% @children.each do |child| %>
+      <% idx += 1 %>
+      <h3 class="action-plan_heading"><span class="index" data-idx="<%= idx %>."></span><%= child.title %></h3>
+
+      <% child.stories.each_with_index do |story, idx2| %>
+        <h4 class="action-plan_heading"><span class="index" data-idx="<%= idx %>.<%= idx2+1 %>."></span><%= story.title %></h4>
+        <%= markdown(story.description) %>
+      <% end %>
     <% end %>
   </div>
 

--- a/spec/features/action_plan_generate_spec.rb
+++ b/spec/features/action_plan_generate_spec.rb
@@ -2,16 +2,27 @@ require "rails_helper"
 
 RSpec.describe "generating an action plan", js: true do
   let(:admin_user) { FactoryBot.create(:user) }
-  let(:project) do
-    FactoryBot.create(:project).tap do |project|
+  let(:parent) do
+    FactoryBot.create(:project)
+  end
+
+  let!(:project) do
+    FactoryBot.create(:project, parent: parent).tap do |project|
       FactoryBot.create(:story, title: "Second Story", description: "Second", position: 2, project: project)
       FactoryBot.create(:story, title: "First Story", description: "First", position: 1, project: project)
     end
   end
 
+  let!(:project2) do
+    FactoryBot.create(:project, parent: parent).tap do |project|
+      FactoryBot.create(:story, title: "Third Story", description: "Third", position: 2, project: project)
+      FactoryBot.create(:story, title: "Forth Story", description: "Forth", position: 1, project: project)
+    end
+  end
+
   before { login_as(admin_user, scope: :user) }
 
-  it "generates copy pasteable report" do
+  it "generates copy pasteable action plan" do
     visit project_path(project)
     click_link "Generate Action Plan"
 
@@ -20,15 +31,29 @@ RSpec.describe "generating an action plan", js: true do
     expect(page).to have_selector("h2", text: "Action Plan")
     expect(page).to have_selector("input[name='action-plan-prefix']")
     expect(page).to have_selector("h3.action-plan_heading > span", visible: false)
-    expect(page.all("#action-plan h3").map(&:text)).to eq(["FIRST STORY", "SECOND STORY"])
+    expect(page.all("#action-plan h3").map(&:text)).to eq(["First Story", "Second Story"])
     expect(page.all("#action-plan p").map(&:text)).to eq(["First", "Second"])
 
     # Set prefix
     page.fill_in "action-plan-prefix", with: "3.2"
-    expect(page.all("h3.action-plan_heading > span").map(&:text)).to eq(["3.2.1", "3.2.2"])
+    expect(page.all(".action-plan_heading > span").map(&:text)).to eq(["3.2.1.", "3.2.2."])
 
     # Ensure that dot is not there when prefix input is empty
     page.fill_in "action-plan-prefix", with: " "
-    expect(page.all("#action-plan h3").map(&:text)).to eq(["FIRST STORY", "SECOND STORY"])
+    expect(page.all("#action-plan h3").map(&:text)).to eq(["First Story", "Second Story"])
+  end
+
+  it "generates copy pasteable action plan for nested projects" do
+    visit project_path(parent)
+    click_link "Generate Action Plan"
+
+    # Check that content is there
+    expect(page).to have_selector("h1", text: parent.title)
+    expect(page).to have_selector("h2", text: "Action Plan")
+    expect(page).to have_selector("input[name='action-plan-prefix']")
+
+    # Set prefix
+    page.fill_in "action-plan-prefix", with: "3"
+    expect(page.all(".action-plan_heading > span").map(&:text)).to eq(["3.1.", "3.1.1.", "3.1.2.", "3.2.", "3.2.1.", "3.2.2."])
   end
 end


### PR DESCRIPTION
**Description:**

This PR updates the action plan generation to be aware of projects with nested projects. When generating an action plan for the parent, it will include any story on the parent and also stories for the nested projects.

I updated a bit of the style too so it's easier for copy pasteing into google docs.

When adding a prefix, the numbering shows up

![image](https://user-images.githubusercontent.com/188464/137915228-1ed98392-779b-4078-b83b-baf9affb0f6f.png)

Closes #78 

I will abide by the [code of conduct](https://github.com/fastruby/points/CODE_OF_CONDUCT.md).
