### PR TITLE
Fix Code of Conduct link in PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -5,5 +5,6 @@
 Please include a summary of the change and which issue is fixed or which feature is introduced. If changes to the behavior are made, clearly describe what changes.
 If changes to the UI are made, please include screenshots of the before and after.
 
+___
 
-I will abide by the [code of conduct](https://github.com/fastruby/points/CODE_OF_CONDUCT.md).
+I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).


### PR DESCRIPTION
**Description:**

The Code of Conduct link of the Pull Request template [is not working](https://github.com/fastruby/points/CODE_OF_CONDUCT.md). This PR adds [the correct link](https://github.com/fastruby/points/blob/main/pull_request_template.md) to it.

Please check it out. Thanks!