### PR TITLE
Fix error when editing two or more estimates

### DIFF
--- a/app/views/estimates/_update_estimates.js.erb
+++ b/app/views/estimates/_update_estimates.js.erb
@@ -1,7 +1,3 @@
-let row = document.getElementById("story_<%= estimate.story_id %>")
-row.children[1].innerText = "<%= j(estimate.best_case_points.to_s) %>"
-row.children[2].innerText = "<%= j(estimate.worst_case_points.to_s) %>"
-
-let totals_row = document.querySelector('.project-table tfoot tr')
-totals_row.children[1].innerText = "<%= j @project.best_estimate_sum_per_user(current_user) %>"
-totals_row.children[2].innerText = "<%= j @project.worst_estimate_sum_per_user(current_user) %>"
+(function(){
+  <%= render partial: "update_row", locals: { estimate: @estimate } %>
+})()

--- a/app/views/estimates/_update_row.js.erb
+++ b/app/views/estimates/_update_row.js.erb
@@ -1,0 +1,7 @@
+let row = document.getElementById("story_<%= estimate.story_id %>")
+row.children[1].innerText = "<%= j(estimate.best_case_points.to_s) %>"
+row.children[2].innerText = "<%= j(estimate.worst_case_points.to_s) %>"
+
+let totals_row = document.querySelector('.project-table tfoot tr')
+totals_row.children[1].innerText = "<%= j @project.best_estimate_sum_per_user(current_user) %>"
+totals_row.children[2].innerText = "<%= j @project.worst_estimate_sum_per_user(current_user) %>"

--- a/app/views/estimates/create.js.erb
+++ b/app/views/estimates/create.js.erb
@@ -1,6 +1,6 @@
 (function(){
   <% if @estimate.persisted? %>
-    <%= render partial: 'update_estimates', locals: {estimate: @estimate} %>
+    <%= render partial: 'update_row', locals: {estimate: @estimate} %>
     const addEstimate = row.querySelector('.add-estimate')
     addEstimate.insertAdjacentHTML('afterend', "<%= j(link_to 'Edit Estimate', edit_project_story_estimate_path(@project.id, @estimate.story, @estimate.id), class: "button green edit-estimate", remote: true) %>")
     addEstimate.remove()

--- a/spec/features/estimates_manage_spec.rb
+++ b/spec/features/estimates_manage_spec.rb
@@ -106,6 +106,14 @@ RSpec.describe "managing estimates" do
 
       cell = find("#story_#{story.id} td:nth-child(2)")
       expect(cell).to have_text("5")
+
+      click_link "Edit Estimate"
+
+      select "8", from: "estimate[best_case_points]"
+      click_button "Save Changes"
+
+      cell = find("#story_#{story.id} td:nth-child(2)")
+      expect(cell).to have_text("8")
     end
 
     it "allows estimation deletion" do


### PR DESCRIPTION
**Description:**

This PR fixes an issue where the js response when editing an estimate would do something like `let row = ...` in the global scope. Then, the second time an edit is made, this would fail trying to re-define the `row` variable.

I update if to not polute the global scope wrapping the response in a function.

Closes #114 
___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
