### PR TITLE
Add helper methods and refactor specs

### DIFF
--- a/spec/features/estimates_manage_spec.rb
+++ b/spec/features/estimates_manage_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe "managing estimates" do
     end
 
     it "allows me to add an estimate" do
-      select "3", from: "estimate[best_case_points]"
-      select "8", from: "estimate[worst_case_points]"
+      set_estimates(3, 8)
       click_button "Create"
       expect(Estimate.count).to eq 1
       expect(page).to have_content "Estimate created!"
@@ -43,8 +42,7 @@ RSpec.describe "managing estimates" do
     end
 
     it "allows me to edit an estimate" do
-      select "1", from: "estimate[best_case_points]"
-      select "2", from: "estimate[worst_case_points]"
+      set_estimates(1, 2)
       click_button "Save Changes"
       expect(page).to have_content "Estimate updated!"
     end
@@ -59,8 +57,7 @@ RSpec.describe "managing estimates" do
     end
 
     it "shows me an error message" do
-      select "21", from: "estimate[best_case_points]"
-      select "1", from: "estimate[worst_case_points]"
+      set_estimates(21, 1)
       click_button "Save Changes"
       expect(page).to have_content "Validation error Worst case estimate should be greater than best case estimate."
     end
@@ -83,58 +80,65 @@ RSpec.describe "managing estimates" do
       visit project_path(id: project.id)
       click_link "Add Estimate"
 
-      expect(page).to have_text("New Estimate")
-      expect(page).to have_content(story.description)
-      expect(current_path).to eq project_path(id: project.id)
+      within_modal do
+        expect(page).to have_text("New Estimate")
+        expect(page).to have_content(story.description)
+        expect(current_path).to eq project_path(id: project.id)
 
-      select "3", from: "estimate[best_case_points]"
-      select "8", from: "estimate[worst_case_points]"
-      click_button "Create"
+        set_estimates(3, 8)
+        click_button "Create"
+      end
+      expect_closed_modal
 
-      cell = find("#story_#{story.id} td:nth-child(2)")
-      expect(cell).to have_text("3")
+      expect_story_estimates(story, 3, 8)
       expect(page).to_not have_content(story.description)
 
       click_link "Edit Estimate"
 
-      expect(page).to have_text("Edit Estimate")
-      expect(current_path).to eq project_path(id: project.id)
-      expect(page).to have_content(story.description)
+      within_modal do
+        expect(page).to have_text("Edit Estimate")
+        expect(current_path).to eq project_path(id: project.id)
+        expect(page).to have_content(story.description)
 
-      select "5", from: "estimate[best_case_points]"
-      click_button "Save Changes"
+        set_estimates(5, 8)
+        click_button "Save Changes"
+      end
+      expect_closed_modal
 
-      cell = find("#story_#{story.id} td:nth-child(2)")
-      expect(cell).to have_text("5")
+      expect_story_estimates(story, 5, 8)
     end
 
     it "allows estimation deletion" do
       visit project_path(id: project.id)
       click_link "Add Estimate"
 
-      expect(page).to have_text("New Estimate")
-      expect(page).to have_content(story.description)
-      expect(current_path).to eq project_path(id: project.id)
+      within_modal do
+        expect(page).to have_text("New Estimate")
+        expect(page).to have_content(story.description)
+        expect(current_path).to eq project_path(id: project.id)
 
-      select "5", from: "estimate[best_case_points]"
-      select "8", from: "estimate[worst_case_points]"
+        set_estimates(5, 8)
 
-      # make sure the delete button is not there during creation
-      expect(page).to have_selector("a", text: "Delete Estimate", count: 0)
+        # make sure the delete button is not there during creation
+        expect(page).to have_selector("a", text: "Delete Estimate", count: 0)
 
-      click_button "Create"
+        click_button "Create"
+      end
+      expect_closed_modal
 
-      cell = find("#story_#{story.id} td:nth-child(2)")
-      expect(cell).to have_text("5")
+      expect_story_estimates(story, 5, 8)
       expect(page).to_not have_content(story.description)
 
       click_link "Edit Estimate"
 
-      expect(page).to have_text("Edit Estimate")
+      within_modal do
+        expect(page).to have_text("Edit Estimate")
 
-      accept_confirm do
-        click_link "Delete Estimate"
+        accept_confirm do
+          click_link "Delete Estimate"
+        end
       end
+      expect_closed_modal
 
       expect(page).to_not have_text("Edit Estimate")
     end

--- a/spec/features/modal_displays_always_spec.rb
+++ b/spec/features/modal_displays_always_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "managing estimates" do
+RSpec.describe "managing estimates", js: true do
   let(:user) { FactoryBot.create(:user) }
   let(:project) { FactoryBot.create(:project) }
   let!(:story) { FactoryBot.create(:story, project: project) }
@@ -9,17 +9,23 @@ RSpec.describe "managing estimates" do
     login_as(user, scope: :user)
   end
 
-  it "allows me to click on the modal twice in a row", js: true do
+  it "allows me to click on the modal twice in a row" do
     visit project_path(id: project.id)
     click_link "Add Estimate"
-    expect(page).to have_text("New Estimate")
-    expect(page).to have_content(story.description)
-    find(".close").click
+
+    within_modal do
+      expect(page).to have_text("New Estimate")
+      expect(page).to have_content(story.description)
+      find(".close").click
+    end
 
     visit "/projects"
     find(".project-card:nth-of-type(1)").click
     click_link "Add Estimate"
-    expect(page).to have_text("New Estimate")
-    expect(page).to have_content(story.description)
+
+    within_modal do
+      expect(page).to have_text("New Estimate")
+      expect(page).to have_content(story.description)
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,6 +39,30 @@ ActiveRecord::Migration.maintain_test_schema!
 
 require "deprecation_tracker"
 
+module FeatureSpecsHelpers
+  def set_estimates(best, worst)
+    select best.to_s, from: "estimate[best_case_points]"
+    select worst.to_s, from: "estimate[worst_case_points]"
+  end
+
+  def within_modal(&block)
+    within ".modal.in" do
+      yield
+    end
+  end
+
+  def expect_closed_modal
+    expect(page).to have_selector ".modal.in", count: 0
+  end
+
+  def expect_story_estimates(story, best, worst)
+    within "#story_#{story.id}" do
+      expect(find("td:nth-child(2)")).to have_text best.to_s
+      expect(find("td:nth-child(3)")).to have_text worst.to_s
+    end
+  end
+end
+
 RSpec.configure do |config|
   # Tracker deprecation messages in each file
   if ENV["DEPRECATION_TRACKER"]
@@ -68,6 +92,7 @@ RSpec.configure do |config|
   end
 
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include FeatureSpecsHelpers, type: :feature
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and


### PR DESCRIPTION
**Description:**

This PR adds a few helper methods that can be used in feature tests to abstract the CSS selectors from the actual test.

Feature tests should describe what a user would do, so having to write CSS selectors is not ideal. With this helpers, the test can be written in a more user focused way.

closes #119 

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
