### PR TITLE
Increase line height to prevent title overlap

### DIFF
--- a/app/assets/stylesheets/2-quarks/_custom_typography.scss
+++ b/app/assets/stylesheets/2-quarks/_custom_typography.scss
@@ -71,7 +71,6 @@ h4 {
 .dashboard-title-report {
   width: 100%;
   position: sticky;
-  top: 53px;
   background: white;
   text-align: left;
   font-size: 35px;


### PR DESCRIPTION
**Description:**
Closes #116 

This fix prevents long project titles from overlapping when the browser window width is reduced. Prior to this fix, when the project title text was long enough to wrap to a new line, the text would overlap. 

Note: I considered using em units, but [MDN Docs say unitless line-height is preferred.](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#prefer_unitless_numbers_for_line-height_values) 

## Screenshots
Using the same example text from issue #116

### Before
![Screen Shot 2021-10-30 at 12 36 09 AM](https://user-images.githubusercontent.com/13709437/139524610-32e0a633-b383-4ec8-9d56-1d2a19240b46.png)

### After
Here is the updated screenshot of working functionality (multiline title in the header doesn't cover the project title).
![Screen Shot 2021-10-31 at 6 03 27 PM](https://user-images.githubusercontent.com/13709437/139608142-78289f94-998b-4fe9-aa6f-91a9f27c3bab.png)
___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
