### PR TITLE
Initialize position on creation and fix order issue for duplicated positions

### DIFF
--- a/app/controllers/action_plans_controller.rb
+++ b/app/controllers/action_plans_controller.rb
@@ -3,7 +3,10 @@ class ActionPlansController < ApplicationController
 
   def show
     @project = Project.find(params[:project_id])
-    @project_stories = @project.stories.order(:position, :created_at)
-    @children = Project.where(parent_id: @project.id).includes(:stories).references(:stories).order("stories.position")
+    @project_stories = @project.stories.by_position
+    @children =
+      Project.where(parent_id: @project.id)
+        .includes(:stories).references(:stories)
+        .order("stories.position ASC NULLS FIRST")
   end
 end

--- a/app/controllers/action_plans_controller.rb
+++ b/app/controllers/action_plans_controller.rb
@@ -3,7 +3,7 @@ class ActionPlansController < ApplicationController
 
   def show
     @project = Project.find(params[:project_id])
-    @project_stories = @project.stories.order(:position)
+    @project_stories = @project.stories.order(:position, :created_at)
     @children = Project.where(parent_id: @project.id).includes(:stories).references(:stories).order("stories.position")
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -59,7 +59,7 @@ class ProjectsController < ApplicationController
 
   def show
     @project = Project.find(params[:id])
-    @stories = @project.stories.order(:position, :created_at)
+    @stories = @project.stories.by_position
   end
 
   def update

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -59,7 +59,7 @@ class ProjectsController < ApplicationController
 
   def show
     @project = Project.find(params[:id])
-    @stories = Story.where(project_id: @project.id).order(:position)
+    @stories = @project.stories.order(:position, :created_at)
   end
 
   def update

--- a/app/controllers/real_scores_controller.rb
+++ b/app/controllers/real_scores_controller.rb
@@ -3,7 +3,7 @@ class RealScoresController < ApplicationController
   before_action :find_project
 
   def edit
-    @stories = @project.stories
+    @stories = @project.stories.by_position
   end
 
   def update

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -9,7 +9,7 @@ class ReportsController < ApplicationController
   def show
     respond_to do |format|
       format.html do
-        @stories = @project.stories
+        @stories = @project.stories.by_position
         @estimates = @project.estimates
         @users = @project.users.uniq
         @real_score_exists = @stories.pluck(:real_score).any?

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -84,7 +84,7 @@ class StoriesController < ApplicationController
   def export
     csv = CSV.generate(headers: true) { |csv|
       csv << CSV_HEADERS
-      @project.stories.each do |story|
+      @project.stories.by_position.each do |story|
         csv << story.attributes.slice(*CSV_HEADERS)
       end
     }

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -10,7 +10,7 @@ class Report
   end
 
   def stories
-    project.stories
+    project.stories.by_position
   end
 
   def to_csv

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -5,6 +5,8 @@ class Story < ApplicationRecord
 
   has_many :estimates
 
+  before_create :add_position
+
   def best_estimate_average
     return 0 if estimates.length < 2
 
@@ -33,5 +35,14 @@ class Story < ApplicationRecord
     else
       0
     end
+  end
+
+  private
+
+  def add_position
+    return if position
+
+    last_position = project.stories.order(position: :asc).last&.position || 0
+    self.position = last_position + 1
   end
 end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -44,7 +44,7 @@ class Story < ApplicationRecord
   def add_position
     return if position
 
-    last_position = project.stories.order(position: :asc).last&.position || 0
+    last_position = project.stories.where.not(position: nil).order(position: :asc).last&.position || 0
     self.position = last_position + 1
   end
 end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -7,6 +7,8 @@ class Story < ApplicationRecord
 
   before_create :add_position
 
+  scope :by_position, -> { order("position ASC NULLS FIRST, created_at ASC") }
+
   def best_estimate_average
     return 0 if estimates.length < 2
 

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -138,5 +138,21 @@ RSpec.describe "managing stories", js: true do
       expect(find("tr:nth-child(1)")).to have_text story1.title
       expect(find("tr:nth-child(2)")).to have_text story2.title
     end
+
+    # check that stories with nil position are listed first
+
+    click_link "Add a Story"
+    fill_in "Title", with: "Story 3"
+    fill_in "Description (Markdown)", with: "desc"
+    click_button "Create"
+
+    story3 = Story.last
+    expect(story3.position).to be 1
+
+    within("#stories") do
+      expect(find("tr:nth-child(1)")).to have_text story1.title
+      expect(find("tr:nth-child(2)")).to have_text story2.title
+      expect(find("tr:nth-child(3)")).to have_text story3.title
+    end
   end
 end


### PR DESCRIPTION
**Description:**

This PR fixes #9 by doing three things:
- now, when a story is created, the `position` attribute is initialized as the last position + 1
- since not all stories in the database have a position, this PR adds a secondary order by created_at to prevent edited stories to show up last by being explicit on how to order stories with duplicated position (in the case of the issue, both stories have a nil position)
- for current projects with stories already with `position == nil`, adding a new story would add a position for it and postgres would move the previous stories to the end when ordering by position, so this also adds a `NULLS FIRST` modifier to the order so old stories with nil position are at the top

**How to test/QA:**

Issue #9 describes the step by step method to reproduce the issue.

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
