### PR TITLE
Add the option to move stories to another project

### DIFF
--- a/app/assets/stylesheets/project.scss
+++ b/app/assets/stylesheets/project.scss
@@ -74,3 +74,27 @@
     }
   }
 }
+
+.move-story-wrapper {
+  display: inline-block;
+  position: relative;
+
+  .move-story-dropdown {
+    opacity: 0;
+    transition: opacity 0.3s;
+    pointer-events: none;
+    position: absolute;
+    right: 0px;
+    top: 100%;
+    z-index: 2;
+
+    input[type="submit"]:hover {
+      background: lightgray;
+    }
+  }
+
+  &:focus-within .move-story-dropdown {
+    opacity: 1;
+    pointer-events: initial;
+  }
+}

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -60,6 +60,7 @@ class ProjectsController < ApplicationController
   def show
     @project = Project.find(params[:id])
     @stories = Story.where(project_id: @project.id).order(:position)
+    @siblings = @project.siblings
   end
 
   def update

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -99,14 +99,14 @@ class StoriesController < ApplicationController
   def move
     @new_project = @project.siblings.find_by(id: params[:to_project])
 
-    if !@new_project
+    if @new_project
+      @story.update_attribute(:project_id, @new_project.id)
+      flash[:success] = "Story moved!"
+    else
       flash[:error] = "Selected project does not exists or is not a sibling."
-      redirect_back(fallback_location: project_path(@project)) and return
     end
 
-    @story.update_attribute(:project_id, @new_project.id)
-    flash[:success] = "Story moved!"
-    redirect_to @new_project
+    redirect_to @project
   end
 
   private

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -2,7 +2,7 @@ require "csv"
 class StoriesController < ApplicationController
   before_action :authenticate_user!
   before_action :find_project, except: [:bulk_destroy, :render_markdown]
-  before_action :find_story, only: [:edit, :update, :destroy, :show]
+  before_action :find_story, only: [:edit, :update, :destroy, :show, :move]
   include ApplicationHelper
 
   CSV_HEADERS = %w[id title description position]
@@ -96,6 +96,19 @@ class StoriesController < ApplicationController
     render plain: markdown(params[:markdown])
   end
 
+  def move
+    @new_project = @project.siblings.find_by(id: params[:to_project])
+
+    if !@new_project
+      flash[:error] = "Selected project does not exists or is not a sibling."
+      redirect_back(fallback_location: project_path(@project)) and return
+    end
+
+    @story.update_attribute(:project_id, @new_project.id)
+    flash[:success] = "Story moved!"
+    redirect_to @new_project
+  end
+
   private
 
   def find_project
@@ -103,7 +116,7 @@ class StoriesController < ApplicationController
   end
 
   def find_story
-    @story = Story.find(params[:id])
+    @story = Story.find(params[:id] || params[:story_id])
   end
 
   def stories_params

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -51,6 +51,6 @@ class Project < ApplicationRecord
 
   # returns all the sub-projects from its parent's project except self
   def siblings
-    parent ? parent.projects.where.not(id: id) : []
+    parent_id ? Project.where(parent_id: parent_id).where.not(id: id) : []
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -48,4 +48,9 @@ class Project < ApplicationRecord
     new_status = archived? ? nil : "archived"
     update_column :status, new_status
   end
+
+  # returns all the sub-projects from its parent's project except self
+  def siblings
+    parent ? parent.projects.where.not(id: id) : []
+  end
 end

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -33,6 +33,16 @@
                 <%= link_to 'Add Estimate', new_project_story_estimate_path(@project.id, story), class: "button green add-estimate", remote: true %>
               <% end %>
               <%= link_to 'Delete', project_story_path(@project.id, story, format: "json"), method: "delete",  data: { confirm: 'Are you sure?', story_id: story.id }, class: "button green delete", remote: true %>
+              <% if @siblings.any? %>
+                <div class="move-story-wrapper">
+                  <button class="button green">Move</button>
+                  <div class="move-story-dropdown">
+                    <% @siblings.each do |to_project| %>
+                      <%= button_to to_project.title, project_story_move_path(@project, story, to_project: to_project), method: :put, data: {confirm: "Are you sure?"} %>
+                    <% end %>
+                  </div>
+                </div>
+              <% end %>
             </td>
           </tr>
         <% end %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -35,7 +35,7 @@
               <%= link_to 'Delete', project_story_path(@project.id, story, format: "json"), method: "delete",  data: { confirm: 'Are you sure?', story_id: story.id }, class: "button green delete", remote: true %>
               <% if @siblings.any? %>
                 <div class="move-story-wrapper">
-                  <button class="button green">Move</button>
+                  <button class="button green">Move to</button>
                   <div class="move-story-dropdown">
                     <% @siblings.each do |to_project| %>
                       <%= button_to to_project.title, project_story_move_path(@project, story, to_project: to_project), method: :put, data: {confirm: "Are you sure?"} %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,12 +23,14 @@ Rails.application.routes.draw do
     resource :report do
       get "download", to: "reports#download"
     end
+
     resources :stories do
       get :real_scores, on: :collection, to: "real_scores#edit"
       patch :real_scores, on: :collection, to: "real_scores#update"
       patch :import, on: :collection
       get :export, on: :collection
       resources :estimates, except: [:index, :show]
+      put :move
     end
     resource :action_plan, only: [:show]
   end

--- a/spec/controllers/stories_controller_spec.rb
+++ b/spec/controllers/stories_controller_spec.rb
@@ -107,4 +107,16 @@ RSpec.describe StoriesController, type: :controller do
       }.to change(Story, :count).by(-2)
     end
   end
+
+  describe "#move" do
+    it "does not allow moving stories to non-sibling projects" do
+      project2 = FactoryBot.create(:project, parent: project)
+      project3 = FactoryBot.create(:project)
+      story = FactoryBot.create(:story, project: project2)
+
+      put :move, params: {project_id: project2.id, story_id: story.id, to_project: project3.id}
+      expect(flash[:error]).to eq "Selected project does not exists or is not a sibling."
+      expect(response).to redirect_to project2
+    end
+  end
 end

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe "managing stories", js: true do
       # move to options are hidden
       expect(page).not_to have_text project3.title
 
-      click_button "Move"
+      click_button "Move to"
 
       # only one option is to move to since there's only one sibling
       expect(page).to have_selector ".move-story-dropdown > form", count: 1

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe "managing stories", js: true do
     end
 
     expect(page).to have_text "Story moved"
+    expect(page).not_to have_text story.title
     expect(story.reload.project).to eq project3
   end
 end

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "managing stories", js: true do
 
   it "allows me to clone a story" do
     visit project_path(id: project.id)
-    within("#story_#{story.id}") { click_link "Clone" }
+    within_story_row(story) { click_link "Clone" }
     expect(page.find("#story_title").value).to eq story.title
     expect(page.find("#story_description").value).to eq story.description
     click_button "Create"
@@ -52,7 +52,7 @@ RSpec.describe "managing stories", js: true do
   it "allows me to bulk delete stories when one or more stories are selected" do
     visit project_path(id: project.id)
 
-    within("#story_#{story.id}") { check(option: story.id.to_s) }
+    within_story_row(story) { check(option: story.id.to_s) }
     expect(page).to have_no_selector("#bulk_delete[aria-disabled='true']")
     expect(page).to have_no_selector("#bulk_delete[disabled]")
     expect(page).to have_button("Bulk Delete (1 Story)")
@@ -85,7 +85,7 @@ RSpec.describe "managing stories", js: true do
     expect(page).to have_text(project.title)
 
     story = Story.last
-    within("#story_#{story.id}") do
+    within_story_row(story) do
       click_link("Edit")
     end
 
@@ -95,5 +95,31 @@ RSpec.describe "managing stories", js: true do
       expect(page).to have_selector("p", text: "This story allows users to add stories.")
       expect(page).to have_selector("pre", text: "some\ncode")
     end
+  end
+
+  it "can move stories between siblings" do
+    project2 = FactoryBot.create(:project, parent: project)
+    project3 = FactoryBot.create(:project, parent: project)
+    story = FactoryBot.create(:story, project: project2)
+
+    visit project_path(id: project2.id)
+
+    within_story_row(story) do
+      # move to options are hidden
+      expect(page).not_to have_text project3.title
+
+      click_button "Move"
+
+      # only one option is to move to since there's only one sibling
+      expect(page).to have_selector ".move-story-dropdown > form", count: 1
+
+      # confirm moving the story
+      accept_confirm do
+        click_button project3.title
+      end
+    end
+
+    expect(page).to have_text "Story moved"
+    expect(story.reload.project).to eq project3
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,6 +45,12 @@ module FeatureSpecsHelpers
     select worst.to_s, from: "estimate[worst_case_points]"
   end
 
+  def within_story_row(story, &block)
+    within "#story_#{story.id}" do
+      yield
+    end
+  end
+
   def within_modal(&block)
     within ".modal.in" do
       yield
@@ -56,7 +62,7 @@ module FeatureSpecsHelpers
   end
 
   def expect_story_estimates(story, best, worst)
-    within "#story_#{story.id}" do
+    within_story_row(story) do
       expect(find("td:nth-child(2)")).to have_text best.to_s
       expect(find("td:nth-child(3)")).to have_text worst.to_s
     end


### PR DESCRIPTION
**Description:**

This PR adds the new feature of moving stories between projects.

- a new `Move to` button is added for each row if the current project is a subproject with siblings
- clicking `Move to` shows all possible siblings of the current project
- after confirmation, the story is moved and the user is redirected back to the initial project

I added a `within_story_row` to abstract the `within("#story_#{story.id}")` selector and updated that in some places

**How to QA/test:**

- Create a project
- Create a few subprojects
- Create a story on any of the subprojects
- The row of the story should have a `Move to` button
- Click the `Move to` button and select another project and confirm the move

The `Move to` button only appears if a project is a subproject and if it has siblings, we don't want to move stories between any possible project.

Closes #132

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
