### PR TITLE
Fix `delete story` flaky spec

### DIFF
--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -37,9 +37,14 @@ RSpec.describe "managing stories", js: true do
 
   it "allows me to delete a story", js: true do
     visit project_path(id: project.id)
+
+    expect(page).to have_text story.title
+
     accept_confirm do
       click_link "Delete"
     end
+
+    expect(page).not_to have_text story.title
     expect(Story.count).to eq 0
   end
 


### PR DESCRIPTION
**Description:**

This PR fixes the flaky `delete story` spec by adding some expectation to make capybara wait for the ajax request to finish before checking the stories' count.

**How to QA/test:**

You can run `rspec ./spec/features/stories_manage_spec.rb:38` multiple times, without this fix it will fail some of the times.

Closes #137 

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
