### PR TITLE
Adjust css layout to better position fixed headers and footer

### DIFF
--- a/app/assets/stylesheets/2-quarks/_custom_typography.scss
+++ b/app/assets/stylesheets/2-quarks/_custom_typography.scss
@@ -80,7 +80,7 @@ h4 {
 
 .fixed-header {
   position: sticky;
-  top: 148px;
+  top: 0px;
   background: white;
   z-index: 1;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,9 +12,9 @@
  *
  */
 
- // "bootstrap-sprockets" must be imported before "bootstrap" and "bootstrap/variables"
- @import "bootstrap-sprockets";
- @import "bootstrap";
+// "bootstrap-sprockets" must be imported before "bootstrap" and "bootstrap/variables"
+@import "bootstrap-sprockets";
+@import "bootstrap";
 //  @import "bourbon";
 
 // 1-UTILITIES
@@ -45,3 +45,30 @@
 @import "project";
 @import "stories";
 @import "action_plans";
+
+body {
+  display: grid;
+  grid-template-rows: min-content 1fr;
+  height: 100vh;
+  overflow: hidden;
+
+  header.navbar {
+    margin-bottom: 0px;
+  }
+
+  header + div {
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+  }
+
+  main {
+    min-height: initial;
+    padding-top: 20px;
+    flex-grow: 1;
+  }
+
+  footer {
+    flex-shrink: 0;
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,11 +11,13 @@
   </head>
   <body class="content <%= controller_name %>-controller <%= action_name %>-action">
     <%= render 'layouts/header' %>
-    <main class="fluid-container">
-      <%= render 'layouts/flash' %>
-      <%= yield %>
-    </main>
-    <%= render 'layouts/footer' %>
+    <div>
+      <main class="fluid-container">
+        <%= render 'layouts/flash' %>
+        <%= yield %>
+      </main>
+      <%= render 'layouts/footer' %>
+    </div>
     <%= render 'layouts/modal' %>
   </body>
 </html>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -2,7 +2,7 @@
   <h1 class="dashboard-title-report"><%= render "shared/project_title", project: @project %></h1>
 
   <table class="project-table">
-    <thead class="table-header">
+    <thead class="table-header fixed-header">
       <tr class="project-table__row project-table__row--header">
         <th class="project-table__cell">Story Title</th>
         <th class="project-table__cell">Best Estimate</th>


### PR DESCRIPTION
**Description:**

This PR updates the CSS used for the general layout of the app to handle the fixed headers and footer better.

It closes #134 and also fixes a regression that broke the feature added here https://github.com/fastruby/points/pull/31

**How to QA/test:**

Try different screens with different amount of content (tables with few or many rows, or the projects index with few or many projects. Without this fix, the footer is sometimes off the screen even when there's space to fit it in the screen and some headers in tables get `sticky` in the wrong place (like the table header of the project report).

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
