### PR TITLE
Monkey patch rspec-rails to work with Rails 7 alpha

### DIFF
--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -12,7 +12,7 @@ GIT
 
 GIT
   remote: https://github.com/rails/rails.git
-  revision: 21c6c225a3f668842e8a4c175f29b9466df4aaa9
+  revision: 2a32c4b679a7fdc370d2f635c5285e4a4f161390
   branch: main
   specs:
     actioncable (7.0.0.alpha2)
@@ -46,6 +46,7 @@ GIT
       activerecord (= 7.0.0.alpha2)
       activestorage (= 7.0.0.alpha2)
       activesupport (= 7.0.0.alpha2)
+      globalid (>= 0.6.0)
       nokogiri (>= 1.8.5)
     actionview (7.0.0.alpha2)
       activesupport (= 7.0.0.alpha2)
@@ -93,7 +94,7 @@ GIT
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
-      zeitwerk (~> 2.5.0.beta6)
+      zeitwerk (~> 2.5)
 
 GIT
   remote: https://github.com/twalpole/apparition.git
@@ -183,10 +184,10 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     ffi (1.15.4)
-    globalid (0.5.2)
+    globalid (1.0.0)
       activesupport (>= 5.0)
     hashie (4.1.0)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
@@ -251,7 +252,7 @@ GEM
     public_suffix (4.0.6)
     puma (4.3.10)
       nio4r (~> 2.0)
-    racc (1.5.2)
+    racc (1.6.0)
     rack (2.2.3)
     rack-protection (2.1.0)
       rack
@@ -378,7 +379,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.5.0.beta6)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   ruby

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,6 +63,18 @@ module FeatureSpecsHelpers
   end
 end
 
+# TODO: remove when rspec-rails is fixed for Rails 7
+# This PR in the main Rails branch https://github.com/rails/rails/pull/43734
+# added a call to the `executor_around_each_request` method
+# that it's not yet supported in RSpec
+# After updating RSpec when Rails 7 is released we will probably be able
+# to delete this
+module RSpec::Rails::RailsExampleGroup
+  def executor_around_each_request
+    true
+  end
+end
+
 RSpec.configure do |config|
   # Tracker deprecation messages in each file
   if ENV["DEPRECATION_TRACKER"]


### PR DESCRIPTION
**Description:**

This PR was merged in the Rails repo 3 days ago https://github.com/rails/rails/pull/43734. This broke rspec because it tries to call the `executor_around_each_request` method which is not defined by the RailsExampleGroup class https://github.com/rails/rails/pull/43734/files#diff-830266b353d76aacab4b00ae785f171b94dc1f9370202aa173ba386b502b6991R584

This PR includes a monkey patch to add the needed method. Eventually, when a new version of RSpec gets released, this can be removed.

There's no fix yet in the main rspec-rails repo to also use rspec from git.

Closes #146
___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
