### PR TITLE
Remove unexpected true string at the end of stories description

### DIFF
--- a/app/models/estimate.rb
+++ b/app/models/estimate.rb
@@ -2,7 +2,7 @@ class Estimate < ApplicationRecord
   belongs_to :story
   belongs_to :user
 
-  validates :best_case_points, :worst_case_points, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :best_case_points, :worst_case_points, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 0}
 
   validate :check_estimates
 

--- a/app/views/estimates/_form.html.erb
+++ b/app/views/estimates/_form.html.erb
@@ -1,4 +1,4 @@
-<%= remote ||= false %>
+<% remote ||= false %>
 
 <%= form_for [project, story, estimate], remote: remote do |f| %>
   <% if estimate.errors.any? %>


### PR DESCRIPTION
**Description:**

This PR closes #112 and is fixing a bug that was showing a `true` string in the form when we were estimating.

Thanks!

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
