### PR TITLE
Update bundler version in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -416,4 +416,4 @@ RUBY VERSION
    ruby 3.0.2p107
 
 BUNDLED WITH
-   2.2.22
+   2.2.26


### PR DESCRIPTION
**Description:**

This PR updates the `bundler` gem version to be the same in `Gemfile` and `Gemfile.lock`

closes #127

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
