### PR TITLE
Fix the text overflow in the title is too long without space and use h4.

### DIFF
--- a/app/assets/stylesheets/stories.scss
+++ b/app/assets/stylesheets/stories.scss
@@ -6,6 +6,10 @@
   margin-top: 0.5em;
 }
 
+.word-break {
+  word-break: break-all;
+}
+
 .story-description {
   margin-bottom: 25px;
   font-size: 15px;

--- a/app/views/shared/_story.html.erb
+++ b/app/views/shared/_story.html.erb
@@ -1,4 +1,4 @@
-<h1>Story #<%= story.id %>: <%= story.title %></h1>
+<h4 class="word-break">Story #<%= story.id %>: <%= story.title %></h4>
 
 <div class="story-description">
   <%= markdown(story.description) %>


### PR DESCRIPTION
**Description:**

Fixes text overflow when the word in a story title is too long.

<img width="595" alt="Screen Shot 2021-12-03 at 02 55 01" src="https://user-images.githubusercontent.com/110372/144507190-2e87e2bf-ef25-4dff-93c2-44bac278a782.png">
___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).

Closes : [Text overflow pane when it's to long](https://github.com/fastruby/points/issues/123)