### PR TITLE
Collapse row actions in a 'more' button and restyle

### DIFF
--- a/app/assets/stylesheets/4-molecules/_tables.scss
+++ b/app/assets/stylesheets/4-molecules/_tables.scss
@@ -11,7 +11,7 @@
   }
   .project-table__row {
     display: grid;
-    grid-template-columns: 40% 10% 10% auto;
+    grid-template-columns: 1fr 70px 70px 260px;
     align-items: center;
     padding: 10px 0;
     &.project-table__row--reports {

--- a/app/assets/stylesheets/project.scss
+++ b/app/assets/stylesheets/project.scss
@@ -75,26 +75,57 @@
   }
 }
 
-.move-story-wrapper {
+.dropdown-wrapper {
   display: inline-block;
   position: relative;
 
-  .move-story-dropdown {
-    opacity: 0;
-    transition: opacity 0.3s;
-    pointer-events: none;
+  .dropdown {
+    display: none;
     position: absolute;
     right: 0px;
-    top: 100%;
+    top: 50%;
     z-index: 2;
+    min-width: 150px;
+    background: white;
+    box-shadow: 1px 1px 4px 2px rgba(0, 0, 0, 0.4);
 
-    input[type="submit"]:hover {
-      background: lightgray;
+    a,
+    button,
+    input {
+      width: 100%;
+      border: 0px;
+      margin: 0px;
+      padding: 0.5rem;
+      background: none;
+      text-align: left;
+      font-size: 1.2rem;
+      font-weight: normal;
+      color: rgb(100, 100, 100);
+
+      &:hover,
+      &:focus-within {
+        color: black;
+      }
+    }
+
+    a.delete,
+    a.delete:hover {
+      color: $dark_magenta;
     }
   }
 
-  &:focus-within .move-story-dropdown {
+  &:focus-within > .dropdown {
+    display: flex;
+    flex-direction: column;
     opacity: 1;
     pointer-events: initial;
+  }
+}
+
+.story_actions {
+  text-align: right;
+  .dropdown-wrapper.more-actions:before {
+    content: "|";
+    display: inline;
   }
 }

--- a/app/assets/stylesheets/project.scss
+++ b/app/assets/stylesheets/project.scss
@@ -128,4 +128,9 @@
     content: "|";
     display: inline;
   }
+
+  .dropdown-wrapper.move-story .dropdown {
+    right: 100%;
+    top: 0px;
+  }
 }

--- a/app/views/estimates/create.js.erb
+++ b/app/views/estimates/create.js.erb
@@ -2,7 +2,7 @@
   <% if @estimate.persisted? %>
     <%= render partial: 'update_row', locals: {estimate: @estimate} %>
     const addEstimate = row.querySelector('.add-estimate')
-    addEstimate.insertAdjacentHTML('afterend', "<%= j(link_to 'Edit Estimate', edit_project_story_estimate_path(@project.id, @estimate.story, @estimate.id), class: "button green edit-estimate", remote: true) %>")
+    addEstimate.insertAdjacentHTML('afterend', "<%= j(link_to 'Edit Estimate', edit_project_story_estimate_path(@project.id, @estimate.story, @estimate.id), class: "button edit-estimate", remote: true) %>")
     addEstimate.remove()
     closeModal()
   <% else %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -5,9 +5,9 @@
     <thead class="table-header fixed-header">
       <tr class="project-table__row project-table__row--header">
         <th class="project-table__cell">Story Title</th>
-        <th class="project-table__cell">Best Estimate</th>
-        <th class="project-table__cell">Worst Estimate</th>
-        <th class="project-table__cell">
+        <th class="project-table__cell">Best<br />Estimate</th>
+        <th class="project-table__cell">Worst<br />Estimate</th>
+        <th class="project-table__cell story_actions">
           <%= link_to "Add a Story", new_project_story_path(@project.id), class: "button magenta"  %>
           <button id="bulk_delete" class="button magenta" aria-disabled="true" disabled>Bulk Delete</button>
         </th>
@@ -24,25 +24,44 @@
             </td>
             <td class="project-table__cell"><%= story.estimates.where(user: current_user)&.first&.best_case_points %></td>
             <td class="project-table__cell"><%= story.estimates.where(user: current_user)&.first&.worst_case_points %></td>
-            <td class="project-table__cell">
-              <%= link_to 'Clone', new_project_story_path(@project.id, story_id: story.id), class: "button green clone" %>
-              <%= link_to 'Edit', edit_project_story_path(@project.id, story), class: "button green edit" %>
+            <td class="project-table__cell story_actions">
               <% if estimated(story) %>
-                <%= link_to 'Edit Estimate', edit_project_story_estimate_path(@project.id, story, @estimate_id), class: "button green edit-estimate", remote: true %>
+                <%= link_to "Edit Estimate", edit_project_story_estimate_path(@project.id, story, @estimate_id), class: "button edit-estimate", remote: true %>
               <% else %>
-                <%= link_to 'Add Estimate', new_project_story_estimate_path(@project.id, story), class: "button green add-estimate", remote: true %>
+                <%= link_to "Add Estimate", new_project_story_estimate_path(@project.id, story), class: "button add-estimate", remote: true %>
               <% end %>
-              <%= link_to 'Delete', project_story_path(@project.id, story, format: "json"), method: "delete",  data: { confirm: 'Are you sure?', story_id: story.id }, class: "button green delete", remote: true %>
-              <% if @siblings.any? %>
-                <div class="move-story-wrapper">
-                  <button class="button green">Move to</button>
-                  <div class="move-story-dropdown">
-                    <% @siblings.each do |to_project| %>
-                      <%= button_to to_project.title, project_story_move_path(@project, story, to_project: to_project), method: :put, data: {confirm: "Are you sure?"} %>
-                    <% end %>
-                  </div>
+              <div class="dropdown-wrapper more-actions">
+                <button class="button" title="More actions">
+                  <i class="fa fa-ellipsis-v"></i>
+                </button>
+                <div class="dropdown">
+                  <%= link_to edit_project_story_path(@project.id, story), class: "button edit", title: "Edit" do %>
+                    <i class="fa fa-pencil-square-o"></i>
+                    <span>Edit</span>
+                  <% end %>
+                  <%= link_to new_project_story_path(@project.id, story_id: story.id), class: "clone", title: "Clone" do %>
+                    <i class="fa fa-files-o"></i>
+                    <span>Clone</span>
+                  <% end %>
+                  <% if @siblings.any? %>
+                    <div class="dropdown-wrapper move-story">
+                      <button title="Move to">
+                        <i class="fa fa-share-square-o"></i>
+                        <span>Move to</span>
+                      </button>
+                      <div class="dropdown">
+                        <% @siblings.each do |to_project| %>
+                          <%= button_to to_project.title, project_story_move_path(@project, story, to_project: to_project), method: :put, data: {confirm: "Are you sure?"} %>
+                        <% end %>
+                      </div>
+                    </div>
+                  <% end %>
+                  <%= link_to project_story_path(@project.id, story, format: "json"), method: "delete",  data: { confirm: 'Are you sure?', story_id: story.id }, class: "delete magenta", remote: true, title: "Delete" do %>
+                    <i class="fa fa-trash-o"></i>
+                    <span>Delete</span>
+                  <% end %>
                 </div>
-              <% end %>
+              </div>
             </td>
           </tr>
         <% end %>

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -20,7 +20,10 @@ RSpec.describe "managing stories", js: true do
 
   it "allows me to clone a story" do
     visit project_path(id: project.id)
-    within_story_row(story) { click_link "Clone" }
+    within_story_row(story) do
+      click_button "More actions"
+      click_link "Clone"
+    end
     expect(page.find("#story_title").value).to eq story.title
     expect(page.find("#story_description").value).to eq story.description
     click_button "Create"
@@ -29,6 +32,7 @@ RSpec.describe "managing stories", js: true do
 
   it "allows me to edit a story" do
     visit project_path(id: project.id)
+    click_button "More actions"
     click_link "Edit"
     fill_in "story[title]", with: "As a user, I want to edit stories"
     click_button "Save Changes"
@@ -41,6 +45,7 @@ RSpec.describe "managing stories", js: true do
     expect(page).to have_text story.title
 
     accept_confirm do
+      click_button "More actions"
       click_link "Delete"
     end
 
@@ -91,7 +96,8 @@ RSpec.describe "managing stories", js: true do
 
     story = Story.last
     within_story_row(story) do
-      click_link("Edit")
+      click_button "More actions"
+      click_link "Edit"
     end
 
     expect(page).to have_text("Edit Story")
@@ -113,10 +119,11 @@ RSpec.describe "managing stories", js: true do
       # move to options are hidden
       expect(page).not_to have_text project3.title
 
+      click_button "More actions"
       click_button "Move to"
 
       # only one option is to move to since there's only one sibling
-      expect(page).to have_selector ".move-story-dropdown > form", count: 1
+      expect(page).to have_selector ".move-story .dropdown > form", count: 1
 
       # confirm moving the story
       accept_confirm do
@@ -155,7 +162,8 @@ RSpec.describe "managing stories", js: true do
     story2.update_attribute(:position, nil)
 
     within("#story_#{story1.id}") do
-      click_link("Edit")
+      click_button "More actions"
+      click_link "Edit"
     end
 
     expect(page).to have_text("Edit Story")


### PR DESCRIPTION
**Description:**

This PR is a restyle of the row's actions in the project's show page. The current group of actions is too big with many option options that are not used too often (like clone, destroy, move to). I also changed the white over green buttons to the less blinding black over yellow colors.

After checking with nathalie, we decided the best UX is to only show the button with text for the main action (add/edit estimates) and group the rest of the actions in a dropdown, instead of showing all the options as buttons as described in the linked issue.

There are other suggestions to improve the colors and hovers style of buttons but I'll add some issues to address those suggestions.

![image](https://user-images.githubusercontent.com/188464/144893939-78231db6-1b21-46d7-b546-7f4f421b4814.png)

`more actions` dropdown
![image](https://user-images.githubusercontent.com/188464/144893993-a226b05d-62df-4f9f-bf07-3bbfa309e7f4.png)

`move to` dropdown
![image](https://user-images.githubusercontent.com/188464/144894009-3b64179c-b9ff-4a39-9e8e-13ab9d593322.png)


Closes #140 

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
