### PR TITLE
Include another `add a story` link in the table footer

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -56,7 +56,9 @@
         <td class="project-table__cell">Total estimates</td>
         <td class="project-table__cell"><%= @project.best_estimate_sum_per_user(current_user) %></td>
         <td class="project-table__cell"><%= @project.worst_estimate_sum_per_user(current_user) %></td>
-        <td class="project-table__cell"></td>
+        <td class="project-table__cell">
+          <%= link_to "Add a Story", new_project_story_path(@project.id), class: "button magenta"  %>
+        </td>
       </tr>
     </tfoot>
 


### PR DESCRIPTION


**Description:**

When there were too many stories for a project, you have to scroll to the top of the page to add a new story. This change adds a link in the table footer.

___
<img width="1007" alt="Screen Shot 2021-12-09 at 17 26 37" src="https://user-images.githubusercontent.com/110372/145390706-7eed2dae-c6e6-4064-9d3b-bb1398c0bb7f.png">




I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
