### PR TITLE
Prevent the creation of multiple estimates

### DIFF
--- a/app/controllers/estimates_controller.rb
+++ b/app/controllers/estimates_controller.rb
@@ -11,8 +11,10 @@ class EstimatesController < ApplicationController
   end
 
   def create
-    @estimate = current_user.estimates.build(estimate_params)
-    @estimate.story_id = params[:story_id]
+    # TODO: change this to `@story.estimate_for(current_user) || ...
+    # when https://github.com/fastruby/points/pull/160 is merged
+    @estimate = @story.estimates.where(user: current_user).first || current_user.estimates.build(story: @story)
+    @estimate.attributes = estimate_params
 
     saved = @estimate.save
     respond_to do |format|
@@ -30,7 +32,6 @@ class EstimatesController < ApplicationController
   end
 
   def update
-    @project = Project.find(params[:project_id])
     updated = @estimate.update(estimate_params)
     respond_to do |format|
       format.html do

--- a/app/controllers/estimates_controller.rb
+++ b/app/controllers/estimates_controller.rb
@@ -11,9 +11,7 @@ class EstimatesController < ApplicationController
   end
 
   def create
-    # TODO: change this to `@story.estimate_for(current_user) || ...
-    # when https://github.com/fastruby/points/pull/160 is merged
-    @estimate = @story.estimates.where(user: current_user).first || current_user.estimates.build(story: @story)
+    @estimate = @story.estimate_for(current_user) || current_user.estimates.build(story: @story)
     @estimate.attributes = estimate_params
 
     saved = @estimate.save

--- a/app/models/estimate.rb
+++ b/app/models/estimate.rb
@@ -3,6 +3,7 @@ class Estimate < ApplicationRecord
   belongs_to :user
 
   validates :best_case_points, :worst_case_points, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+  validates :story_id, uniqueness: {scope: :user_id}
 
   validate :check_estimates
 

--- a/spec/controllers/estimates_controller_spec.rb
+++ b/spec/controllers/estimates_controller_spec.rb
@@ -99,9 +99,7 @@ RSpec.describe EstimatesController, type: :controller do
         }
       end
 
-      before :each do
-        @estimate = FactoryBot.create(:estimate, story: story, user: user, best_case_points: 2, worst_case_points: 5)
-      end
+      let!(:estimate) { FactoryBot.create(:estimate, story: story, user: user, best_case_points: 2, worst_case_points: 5) }
 
       it "does not create a new estimate" do
         expect {
@@ -110,14 +108,14 @@ RSpec.describe EstimatesController, type: :controller do
       end
 
       it "updates the current estimate" do
-        expect(@estimate.best_case_points).to be 2
-        expect(@estimate.worst_case_points).to be 5
+        expect(estimate.best_case_points).to be 2
+        expect(estimate.worst_case_points).to be 5
 
         post :create, params: params
 
-        @estimate.reload
-        expect(@estimate.best_case_points).to be 1
-        expect(@estimate.worst_case_points).to be 3
+        estimate.reload
+        expect(estimate.best_case_points).to be 1
+        expect(estimate.worst_case_points).to be 3
       end
     end
   end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Story, type: :model do
   it { should belong_to(:project) }
 
   let!(:user) { FactoryBot.create(:user) }
+  let(:user2) { FactoryBot.create(:user) }
 
   describe "#best_estimate_average" do
     context "there are no estimates" do
@@ -30,7 +31,7 @@ RSpec.describe Story, type: :model do
     end
     context "there are two or more estimates" do
       let(:estimate_1) { Estimate.new(best_case_points: 10, worst_case_points: 20, user: user) }
-      let(:estimate_2) { Estimate.new(best_case_points: 100, worst_case_points: 200, user: user) }
+      let(:estimate_2) { Estimate.new(best_case_points: 100, worst_case_points: 200, user: user2) }
 
       subject {
         result = FactoryBot.create(:story)
@@ -98,9 +99,10 @@ RSpec.describe Story, type: :model do
         expect(subject.worst_estimate_average).to eq(0)
       end
     end
+
     context "there are two or more estimates" do
       let(:estimate_1) { Estimate.new(best_case_points: 10, worst_case_points: 20, user: user) }
-      let(:estimate_2) { Estimate.new(best_case_points: 100, worst_case_points: 200, user: user) }
+      let(:estimate_2) { Estimate.new(best_case_points: 100, worst_case_points: 200, user: user2) }
 
       subject {
         result = FactoryBot.create(:story)


### PR DESCRIPTION
**Description:**

This PR closes #142 by checking if there's currently an estimate for a story for the given user before creating a new estimate. If an estimage for the [story, user] already exists, the create action updates it instead of creating an new one.

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
