### PR TITLE
Add story filter feature

### DIFF
--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -64,3 +64,22 @@ window.addEventListener("load", () => {
     });
   });
 });
+
+const filterStories = () => {
+  const searchTerm = document.getElementById("title_contains").value.toLowerCase().trim();
+  if (searchTerm.length == 0) {
+    $("#stories").sortable("enable");
+  } else {
+    $("#stories").sortable("disable");
+  }
+
+  document.querySelectorAll("#stories tr").forEach(function(element) {
+    const cl = element.classList
+    const storyTitle = element.querySelector("td:first-child").innerText.toLowerCase()
+    if (storyTitle.includes(searchTerm)) {
+      cl.remove("hidden")
+    } else {
+      cl.add("hidden")
+    }
+  })
+};

--- a/app/assets/stylesheets/project.scss
+++ b/app/assets/stylesheets/project.scss
@@ -134,3 +134,24 @@
     top: 0px;
   }
 }
+
+.header {
+  display: flex;
+}
+
+.search-field {
+  position: relative;
+  padding: 0;
+  min-width: 250px;
+  
+  label {
+    position: absolute;
+    margin-top: 0;
+    top: -10px;
+    left: 5px;
+    padding: 0px 3px;
+    background: white;
+    font-size: 90%;
+    color: gray;
+  }
+}

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,5 +1,12 @@
 <div class="container">
-  <h1 class="dashboard-title-report"><%= render "shared/project_title", project: @project %></h1>
+  <div class="header">
+    <h1 class="dashboard-title-report"><%= render "shared/project_title", project: @project %></h1>
+
+    <div class="search-field">
+      <%= label_tag 'title_contains', "Filter by title" %>
+      <%= search_field_tag 'title_contains', nil, onkeyup: "filterStories()" %>
+    </div>
+  </div>
 
   <table class="project-table">
     <thead class="table-header fixed-header">


### PR DESCRIPTION
**Description:**

This PR adds a search bar at the top of the stories table that allows us to filter the stories by their names, using a debounce function @fbuys graciously taught me to implement.

I believe there might be some usability questions so I'd be grateful for some feedback in that area.

So, before, we had this:
![image](https://user-images.githubusercontent.com/14188887/145649029-e5639227-dafc-43ca-97c7-9dd631b2e6d6.png)

And here's the search bar:
![image](https://user-images.githubusercontent.com/14188887/145649067-b020cbdc-850a-4fda-acc2-3210ff763008.png)

Should this be merged, it closes #49
___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
