### PR TITLE
Add rubocop config with standardrb rules

### DIFF
--- a/.pre-commit
+++ b/.pre-commit
@@ -1,2 +1,2 @@
 #!/bin/bash
-bundle exec standardrb
+bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,18 @@
+require:
+  - standard
+
+inherit_gem:
+  standard: config/base.yml # use the standardrb config file as the base
+
+AllCops:
+  SuggestExtensions: false
+  NewCops: enable
+  Exclude: # ignore files in these directories when running the linter
+    - bin/**/*
+    - node_modules/**/*
+    - public/**/*
+    - vendor/**/*
+    - db/schema.rb
+
+Bundler/DuplicatedGem:
+  Enabled: false # ignore duplicated gem error

--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "spring"
   gem "spring-watcher-listen", "~> 2.0.0"
-  gem "standardrb"
+  gem "standardrb", require: false
 end
 
 group :development, :test do

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -27,7 +27,7 @@ class Story < ApplicationRecord
     # cache the estimate for each user to not process it every time
     @estimate_for ||= {}
     # use the `estimates` association directly to use the cached query to prevent N+1
-    @estimate_for[user] ||= estimates.select{ |e| e.user == user }.sort_by{|e| e.id}.first
+    @estimate_for[user] ||= estimates.select { |e| e.user == user }.min_by { |e| e.id }
     @estimate_for[user]
   end
 
@@ -52,7 +52,7 @@ class Story < ApplicationRecord
   end
 
   def users_estimates
-    @users_estimates ||= users.distinct.map{ |u| estimate_for(u) }
+    @users_estimates ||= users.distinct.map { |u| estimate_for(u) }
   end
 
   private

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
-load Gem.bin_path('bundler', 'bundle')
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
+load Gem.bin_path("bundler", "bundle")

--- a/bin/rails
+++ b/bin/rails
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 begin
-  load File.expand_path('../spring', __FILE__)
+  load File.expand_path("../spring", __FILE__)
 rescue LoadError => e
-  raise unless e.message.include?('spring')
+  raise unless e.message.include?("spring")
 end
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/bin/rake
+++ b/bin/rake
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 begin
-  load File.expand_path('../spring', __FILE__)
+  load File.expand_path("../spring", __FILE__)
 rescue LoadError => e
-  raise unless e.message.include?('spring')
+  raise unless e.message.include?("spring")
 end
-require_relative '../config/boot'
-require 'rake'
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/bin/setup
+++ b/bin/setup
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
-require 'pathname'
-require 'fileutils'
+require "pathname"
+require "fileutils"
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+APP_ROOT = Pathname.new File.expand_path("../../", __FILE__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -14,34 +14,34 @@ chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler -v 2.2.26 --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler -v 2.2.26 --conservative"
+  system("bundle check") || system!("bundle install")
 
   # Install JavaScript dependencies if using Yarn
   # system('bin/yarn')
 
   puts "\n== Copying sample files =="
-  unless File.exist?('config/database.yml')
-    cp 'config/database.yml.sample', 'config/database.yml'
+  unless File.exist?("config/database.yml")
+    cp "config/database.yml.sample", "config/database.yml"
   end
 
-  unless File.exist?('.env')
-    cp '.env.sample', '.env'
+  unless File.exist?(".env")
+    cp ".env.sample", ".env"
     puts "\n\e[93m=== IMPORTANT: Make sure you fill out details in .env\033[0m"
   end
 
   puts "\n== Preparing database =="
-  system! 'bin/rails db:setup'
-  system! 'bin/rails db:seed'
+  system! "bin/rails db:setup"
+  system! "bin/rails db:seed"
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Adding pre-commit hook =="
-  system! 'cp .pre-commit .git/hooks/pre-commit'
-  system! 'chmod +x .git/hooks/pre-commit'
+  system! "cp .pre-commit .git/hooks/pre-commit"
+  system! "chmod +x .git/hooks/pre-commit"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/bin/spring
+++ b/bin/spring
@@ -4,14 +4,14 @@
 # It gets overwritten when you run the `spring binstub` command.
 
 unless defined?(Spring)
-  require 'rubygems'
-  require 'bundler'
+  require "rubygems"
+  require "bundler"
 
   lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
   spring = lockfile.specs.detect { |spec| spec.name == "spring" }
   if spring
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
-    gem 'spring', spring.version
-    require 'spring/binstub'
+    gem "spring", spring.version
+    require "spring/binstub"
   end
 end

--- a/bin/update
+++ b/bin/update
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
-require 'pathname'
-require 'fileutils'
+require "pathname"
+require "fileutils"
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+APP_ROOT = Pathname.new File.expand_path("../../", __FILE__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -14,16 +14,16 @@ chdir APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 
   puts "\n== Updating database =="
-  system! 'bin/rails db:migrate'
+  system! "bin/rails db:migrate"
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/bin/yarn
+++ b/bin/yarn
@@ -1,11 +1,9 @@
 #!/usr/bin/env ruby
-VENDOR_PATH = File.expand_path('..', __dir__)
+VENDOR_PATH = File.expand_path("..", __dir__)
 Dir.chdir(VENDOR_PATH) do
-  begin
-    exec "yarnpkg #{ARGV.join(" ")}"
-  rescue Errno::ENOENT
-    $stderr.puts "Yarn executable was not detected in the system."
-    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
-    exit 1
-  end
+  exec "yarnpkg #{ARGV.join(" ")}"
+rescue Errno::ENOENT
+  warn "Yarn executable was not detected in the system."
+  warn "Download Yarn at https://yarnpkg.com/en/docs/install"
+  exit 1
 end


### PR DESCRIPTION
**Description:**

This PR changes the linter configuration to use rubocop with standardrb rules instead of standardrb directly, to prevent the issues with the pre-commit hook complaining about duplicated gems because of dual booting.

User that already have the pre-commit hook installed must manually change the content of `.git/hooks/pre-commit` from `bundle exec standardrb` to `bundle exec rubocop` or re-run the `bin/setup` script to udpate it.

**How to test/QA:**

Before these changes, trying to make a commit with the pre-commit hook fails with
```
standard: Use Ruby Standard Style (https://github.com/testdouble/standard)
  Gemfile:18:3: Bundler/DuplicatedGem: Gem `rails` requirements already given on line 15 of the Gemfile.
  Gemfile:19:3: Bundler/DuplicatedGem: Gem `devise` requirements already given on line 16 of the Gemfile.
```

Closes #167 

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
