### PR TITLE
Use `developer` strategy for review app logins

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,18 @@
+{
+  "name": "points",
+  "scripts": {
+    "postdeploy": "bundle exec rails db:migrate"
+  },
+  "env": {},
+  "formation": {
+    "web": {
+      "quantity": 1
+    }
+  },
+  "addons": ["heroku-postgresql"],
+  "buildpacks": [
+    {
+      "url": "heroku/ruby"
+    }
+  ]
+}

--- a/app/controllers/callbacks_controller.rb
+++ b/app/controllers/callbacks_controller.rb
@@ -1,7 +1,6 @@
 require "open-uri"
 
 class CallbacksController < Devise::OmniauthCallbacksController
-  before_action :handle_proxy_requests
   skip_before_action :verify_authenticity_token, only: :developer
 
   def github
@@ -25,13 +24,6 @@ class CallbacksController < Devise::OmniauthCallbacksController
   end
 
   private
-
-  def handle_proxy_requests
-    if params["proxy_to"]
-      path = request.fullpath.gsub(/proxy_to=[^&]*&/, "")
-      redirect_to "#{params["proxy_to"]}#{path}"
-    end
-  end
 
   def organization_members
     @organization_members ||= begin

--- a/app/controllers/callbacks_controller.rb
+++ b/app/controllers/callbacks_controller.rb
@@ -2,6 +2,7 @@ require "open-uri"
 
 class CallbacksController < Devise::OmniauthCallbacksController
   before_action :handle_proxy_requests
+  skip_before_action :verify_authenticity_token, only: :developer
 
   def github
     username = request.env["omniauth.auth"]["extra"]["raw_info"]["login"]
@@ -16,6 +17,11 @@ class CallbacksController < Devise::OmniauthCallbacksController
       flash[:error] = "This application is only available to members of #{organization_name}."
       redirect_to new_user_session_path
     end
+  end
+
+  def developer
+    @user = User.from_omniauth(request.env["omniauth.auth"])
+    sign_in_and_redirect @user
   end
 
   private

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -256,8 +256,11 @@ Devise.setup do |config|
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
-  config.omniauth :github, ENV["GITHUB_APP_ID"], ENV["GITHUB_APP_SECRET"], scope: "user:email"
-
+  if ENV["HEROKU_APP_NAME"]
+    config.omniauth :developer, scope: "user:email"
+  else
+    config.omniauth :github, ENV["GITHUB_APP_ID"], ENV["GITHUB_APP_SECRET"], scope: "user:email"
+  end
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.

--- a/spec/controllers/callbacks_controller_spec.rb
+++ b/spec/controllers/callbacks_controller_spec.rb
@@ -11,19 +11,10 @@ RSpec.describe CallbacksController, type: :controller do
   end
 
   describe "#github" do
-    context "with a proxy_to param" do
-      it "redirects to provided host" do
-        get :github, params: {proxy_to: "http://example.com", code: "code", state: "state"}
-        expect(subject).to redirect_to("http://example.com/users/auth/github/callback?code=code&state=state")
-      end
-    end
-
-    context "without a proxy_to param" do
-      it "redirects user to sign in" do
-        allow_any_instance_of(CallbacksController).to receive(:organization_members).and_return([])
-        get :github, params: {code: "code", state: "state"}
-        expect(subject).to redirect_to("http://test.host/users/sign_in")
-      end
+    it "redirects user to sign in" do
+      allow_any_instance_of(CallbacksController).to receive(:organization_members).and_return([])
+      get :github, params: {code: "code", state: "state"}
+      expect(subject).to redirect_to("http://test.host/users/sign_in")
     end
   end
 end


### PR DESCRIPTION
**Description:**
Fixes #48 once done

As the title says, this makes points use the OmniAuth developer strategy whenever the `HEROKU_APP_NAME` env var is present (i.e.: in review apps). The only UI "change" (since I just used the default page omniauth gives us) is that, when signing in via the developer strategy, we need to inform a name and email in this separate screen:
![image](https://user-images.githubusercontent.com/14188887/146067539-16f4e0d9-80aa-4282-b0d9-e6695fb433e0.png)

I put no error handling since this is only for the review apps, so make sure to just provide some name and any email that obeys the email format, otherwise it will always take you back to the sign in screen

**How to test**
Simply open the app in the root page and click `Sign In` and then `Sign In with Developer`.

Note that, to test this locally, you'll need to run points setting the `HEROKU_APP_NAME` env var. Personally, I just do `HEROKU_APP_NAME="giberish" rails s`, since it only tests for presence and not the value of the env var
___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
