### PR TITLE
Modify the grid size in the navbar header.

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,10 +1,10 @@
 <header class="navbar navbar-inverse">
   <div class="container">
     <div class="row">
-      <div class="col-xs-6">
+      <div class="col-xs-10">
         <%= link_to header_title, header_link, id: "logo" %>
       </div>
-      <div class="col-xs-6">
+      <div class="col-xs-2">
         <nav>
           <ul class="nav">
             <% if current_user %>


### PR DESCRIPTION
**Description:**
Increase the grid size for the Project title in the navbar header.
___
Before:
<img width="996" alt="Screen Shot 2021-12-15 at 03 14 19" src="https://user-images.githubusercontent.com/110372/146085523-e10d753c-3a3c-4563-a2e7-dd0ddb472b25.png">

After:
<img width="1163" alt="Screen Shot 2021-12-15 at 03 32 08" src="https://user-images.githubusercontent.com/110372/146085472-373df1ba-d7da-4f89-9230-c38db9b9731c.png">



closes #164 

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
