### PR TITLE
Refactor project navigation

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -64,7 +64,6 @@ body {
 
   main {
     min-height: initial;
-    // padding-top: 20px;
     flex-grow: 1;
   }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -64,7 +64,7 @@ body {
 
   main {
     min-height: initial;
-    padding-top: 20px;
+    // padding-top: 20px;
     flex-grow: 1;
   }
 

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -3,7 +3,8 @@
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
 /* Universal */
-.home-title{
+.home-title {
   padding: 0 15px;
+  margin-top: 20px;
   margin-bottom: 30px;
 }

--- a/app/assets/stylesheets/project.scss
+++ b/app/assets/stylesheets/project.scss
@@ -156,12 +156,16 @@
 
 .header {
   display: flex;
+  h1 {
+    flex-grow: 1;
+  }
 }
 
 .search-field {
   position: relative;
   padding: 0;
   min-width: 250px;
+  margin-top: 25px;
 
   label {
     position: absolute;

--- a/app/assets/stylesheets/project.scss
+++ b/app/assets/stylesheets/project.scss
@@ -57,10 +57,6 @@
   }
 }
 
-.project-details {
-  margin-top: 15px;
-}
-
 .card-deck {
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
@@ -136,5 +132,25 @@
   .dropdown-wrapper.move-story .dropdown {
     right: 100%;
     top: 0px;
+  }
+}
+
+.hierarchy {
+  position: sticky;
+  top: 0px;
+  h3,
+  h4 {
+    margin-bottom: 10px;
+  }
+  ul {
+    padding-left: 1.5em;
+    list-style-type: initial;
+    li {
+      padding-bottom: 0.2rem;
+      a {
+        display: inline-block;
+        vertical-align: text-top;
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/project.scss
+++ b/app/assets/stylesheets/project.scss
@@ -57,6 +57,10 @@
   }
 }
 
+.project-details {
+  margin-top: 15px;
+}
+
 .card-deck {
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;

--- a/app/assets/stylesheets/project.scss
+++ b/app/assets/stylesheets/project.scss
@@ -138,7 +138,6 @@
 .hierarchy {
   position: sticky;
   top: 0px;
-  h3,
   h4 {
     margin-bottom: 10px;
   }

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -59,7 +59,7 @@ class ProjectsController < ApplicationController
 
   def show
     @project = Project.find(params[:id])
-    @sub_projects = @project.projects
+    @sidebar_projects = @project.parent ? @project.parent.projects : @project.projects
     @stories = @project.stories.by_position.includes(:estimates)
     @siblings = @project.siblings
   end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -59,6 +59,7 @@ class ProjectsController < ApplicationController
 
   def show
     @project = Project.find(params[:id])
+    @sub_projects = @project.projects
     @stories = @project.stories.by_position.includes(:estimates)
     @siblings = @project.siblings
   end

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -3,4 +3,8 @@ module ProjectsHelper
     @estimate_id = story.estimate_for(current_user)
     @estimate_id.present?
   end
+
+  def has_projects?(sub_projects, siblings)
+    sub_projects.any? || siblings.any?
+  end
 end

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -3,8 +3,4 @@ module ProjectsHelper
     @estimate_id = story.estimate_for(current_user)
     @estimate_id.present?
   end
-
-  def has_projects?(sub_projects, siblings)
-    sub_projects.any? || siblings.any?
-  end
 end

--- a/app/views/action_plans/show.html.erb
+++ b/app/views/action_plans/show.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <h1 class="dashboard-title"><%= @project.title %></h1>
+  <h1 class="dashboard-title"><%= render "shared/project_title", project: @project %></h1>
   <button class="btn btn-clipboard" data-clipboard-target="#action-plan-content">Copy to clipboard</button>
 
   <div id="action-plan">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,93 +1,109 @@
 <div class="container">
-  <h1 class="dashboard-title-report"><%= render "shared/project_title", project: @project %></h1>
+  <h1 class="dashboard-title-report">
+    <%= render "shared/project_title", project: @project %>
+  </h1>
 
-  <table class="project-table">
-    <thead class="table-header fixed-header">
-      <tr class="project-table__row project-table__row--header">
-        <th class="project-table__cell">Story Title</th>
-        <th class="project-table__cell">Best<br />Estimate</th>
-        <th class="project-table__cell">Worst<br />Estimate</th>
-        <th class="project-table__cell story_actions">
-          <%= link_to "Add a Story", new_project_story_path(@project.id), class: "button magenta"  %>
-          <button id="bulk_delete" class="button magenta" aria-disabled="true" disabled>Bulk Delete</button>
-        </th>
-      </tr>
-    </thead>
-
-    <tbody id="stories" data-url="<%= sort_project_path(@project.id) %>">
-      <% if @stories.present? %>
-        <% @stories.each do | story | %>
-          <tr class="project-table__row project-table__row--story" id="<%= dom_id(story)%>" >
-            <td class="project-table__cell">
-              <input type="checkbox" name="stories[]" value=<%= story.id %>>
-              <%= link_to story.title, [story.project, story] %>
-            </td>
-            <td class="project-table__cell"><%= story.estimate_for(current_user)&.best_case_points %></td>
-            <td class="project-table__cell"><%= story.estimate_for(current_user)&.worst_case_points %></td>
-            <td class="project-table__cell story_actions">
-              <% if estimated(story) %>
-                <%= link_to "Edit Estimate", edit_project_story_estimate_path(@project.id, story, @estimate_id), class: "button edit-estimate", remote: true %>
-              <% else %>
-                <%= link_to "Add Estimate", new_project_story_estimate_path(@project.id, story), class: "button add-estimate", remote: true %>
-              <% end %>
-              <div class="dropdown-wrapper more-actions">
-                <button class="button" title="More actions">
-                  <i class="fa fa-ellipsis-v"></i>
-                </button>
-                <div class="dropdown">
-                  <%= link_to edit_project_story_path(@project.id, story), class: "button edit", title: "Edit" do %>
-                    <i class="fa fa-pencil-square-o"></i>
-                    <span>Edit</span>
-                  <% end %>
-                  <%= link_to new_project_story_path(@project.id, story_id: story.id), class: "clone", title: "Clone" do %>
-                    <i class="fa fa-files-o"></i>
-                    <span>Clone</span>
-                  <% end %>
-                  <% if @siblings.any? %>
-                    <div class="dropdown-wrapper move-story">
-                      <button title="Move to">
-                        <i class="fa fa-share-square-o"></i>
-                        <span>Move to</span>
-                      </button>
-                      <div class="dropdown">
-                        <% @siblings.each do |to_project| %>
-                          <%= button_to to_project.title, project_story_move_path(@project, story, to_project: to_project), method: :put, data: {confirm: "Are you sure?"} %>
-                        <% end %>
-                      </div>
-                    </div>
-                  <% end %>
-                  <%= link_to project_story_path(@project.id, story, format: "json"), method: "delete",  data: { confirm: 'Are you sure?', story_id: story.id }, class: "delete magenta", remote: true, title: "Delete" do %>
-                    <i class="fa fa-trash-o"></i>
-                    <span>Delete</span>
-                  <% end %>
-                </div>
-              </div>
-            </td>
-          </tr>
+  <div class="row project-details">
+    <div class="col-md-3 sub-project">
+      <% if @sub_projects.any? %>
+        <h4> Sub Projects </h4>
+        <div>
+        <% @sub_projects.each do |sub_project| %>
+          <%= link_to sub_project.title, project_path(sub_project), class: "project-card" %>
         <% end %>
-      <% else %>
-          <p> You don't have any stories yet. </p>
+        </div>
       <% end %>
-    </tbody>
-
-    <tfoot>
-      <tr class="project-table__row project-table__row--footer">
-        <td class="project-table__cell">Total estimates</td>
-        <td class="project-table__cell"><%= @project.best_estimate_sum_per_user(current_user) %></td>
-        <td class="project-table__cell"><%= @project.worst_estimate_sum_per_user(current_user) %></td>
-        <td class="project-table__cell"></td>
-      </tr>
-    </tfoot>
-  </table>
-
-  <% if @sub_projects.any? %>
-    <div class="row">
-      <h4> Sub Projects </h4>
-      <% @sub_projects.each do |sub_project| %>
-        <%= link_to sub_project.title, project_path(sub_project), class: "project-card" %>
+      <% if @siblings.any? %>
+        <h4> Siblings </h4>
+        <div>
+        <% @siblings.each do |sibling| %>
+          <%= link_to sibling.title, project_path(sibling), class: "project-card" %>
+        <% end %>
+        </div>
       <% end %>
     </div>
-  <% end %>
+    <div class="col-md-9">
+      <table class="project-table">
+        <thead class="table-header fixed-header">
+          <tr class="project-table__row project-table__row--header">
+            <th class="project-table__cell">Story Title</th>
+            <th class="project-table__cell">Best<br />Estimate</th>
+            <th class="project-table__cell">Worst<br />Estimate</th>
+            <th class="project-table__cell story_actions">
+              <%= link_to "Add a Story", new_project_story_path(@project.id), class: "button magenta"  %>
+              <button id="bulk_delete" class="button magenta" aria-disabled="true" disabled>Bulk Delete</button>
+            </th>
+          </tr>
+        </thead>
+
+        <tbody id="stories" data-url="<%= sort_project_path(@project.id) %>">
+          <% if @stories.present? %>
+            <% @stories.each do | story | %>
+              <tr class="project-table__row project-table__row--story" id="<%= dom_id(story)%>" >
+                <td class="project-table__cell">
+                  <input type="checkbox" name="stories[]" value=<%= story.id %>>
+                  <%= link_to story.title, [story.project, story] %>
+                </td>
+                <td class="project-table__cell"><%= story.estimate_for(current_user)&.best_case_points %></td>
+                <td class="project-table__cell"><%= story.estimate_for(current_user)&.worst_case_points %></td>
+                <td class="project-table__cell story_actions">
+                  <% if estimated(story) %>
+                    <%= link_to "Edit Estimate", edit_project_story_estimate_path(@project.id, story, @estimate_id), class: "button edit-estimate", remote: true %>
+                  <% else %>
+                    <%= link_to "Add Estimate", new_project_story_estimate_path(@project.id, story), class: "button add-estimate", remote: true %>
+                  <% end %>
+                  <div class="dropdown-wrapper more-actions">
+                    <button class="button" title="More actions">
+                      <i class="fa fa-ellipsis-v"></i>
+                    </button>
+                    <div class="dropdown">
+                      <%= link_to edit_project_story_path(@project.id, story), class: "button edit", title: "Edit" do %>
+                        <i class="fa fa-pencil-square-o"></i>
+                        <span>Edit</span>
+                      <% end %>
+                      <%= link_to new_project_story_path(@project.id, story_id: story.id), class: "clone", title: "Clone" do %>
+                        <i class="fa fa-files-o"></i>
+                        <span>Clone</span>
+                      <% end %>
+                      <% if @siblings.any? %>
+                        <div class="dropdown-wrapper move-story">
+                          <button title="Move to">
+                            <i class="fa fa-share-square-o"></i>
+                            <span>Move to</span>
+                          </button>
+                          <div class="dropdown">
+                            <% @siblings.each do |to_project| %>
+                              <%= button_to to_project.title, project_story_move_path(@project, story, to_project: to_project), method: :put, data: {confirm: "Are you sure?"} %>
+                            <% end %>
+                          </div>
+                        </div>
+                      <% end %>
+                      <%= link_to project_story_path(@project.id, story, format: "json"), method: "delete",  data: { confirm: 'Are you sure?', story_id: story.id }, class: "delete magenta", remote: true, title: "Delete" do %>
+                        <i class="fa fa-trash-o"></i>
+                        <span>Delete</span>
+                      <% end %>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            <% end %>
+          <% else %>
+            <p> You don't have any stories yet. </p>
+          <% end %>
+        </tbody>
+        <tfoot>
+          <tr class="project-table__row project-table__row--footer">
+            <td class="project-table__cell">Total estimates</td>
+            <td class="project-table__cell"><%= @project.best_estimate_sum_per_user(current_user) %></td>
+            <td class="project-table__cell"><%= @project.worst_estimate_sum_per_user(current_user) %></td>
+            <td class="project-table__cell"></td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  </div>
+
+
 
   <%= render partial: "projects/import_export" %>
 

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -82,8 +82,8 @@
       </table>
     </div>
 
-    <aside class="col-xs-2 hierarchy">
-      <% if @sidebar_projects.any? %>
+    <% if @sidebar_projects.any? %>
+      <aside class="col-xs-2 hierarchy">
         <h4>Hierarchy</h4>
         <label>Parent:</label>
         <% top = @project.parent ? @project.parent : @project %>
@@ -94,8 +94,8 @@
             <li><%= link_to sub_project.title, project_path(sub_project) %></li>
           <% end %>
         </ul>
-      <% end %>
-    </aside>
+      </aside>
+    <% end %>
   </div>
 
 

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -78,8 +78,17 @@
         <td class="project-table__cell"></td>
       </tr>
     </tfoot>
-
   </table>
+
+  <% if @sub_projects.any? %>
+    <div class="row">
+      <h4> Sub Projects </h4>
+      <% @sub_projects.each do |sub_project| %>
+        <%= link_to sub_project.title, project_path(sub_project), class: "project-card" %>
+      <% end %>
+    </div>
+  <% end %>
+
   <%= render partial: "projects/import_export" %>
 
   <div class="btn-group">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,30 +1,8 @@
 <div class="container">
-  <h1 class="dashboard-title-report">
-    <%= render "shared/project_title", project: @project %>
-  </h1>
+  <h1 class="dashboard-title"><%= render "shared/project_title", project: @project %></h1>
 
   <div class="row project-details">
-  <% if has_projects?(@sub_projects, @siblings) %>
-    <div class="col-md-3">
-      <% if @sub_projects.any? %>
-        <h4> Sub Projects </h4>
-        <div>
-        <% @sub_projects.each do |sub_project| %>
-          <%= link_to sub_project.title, project_path(sub_project), class: "project-card" %>
-        <% end %>
-        </div>
-      <% end %>
-      <% if @siblings.any? %>
-        <h4> Siblings </h4>
-        <div>
-        <% @siblings.each do |sibling| %>
-          <%= link_to sibling.title, project_path(sibling), class: "project-card" %>
-        <% end %>
-        </div>
-      <% end %>
-    </div>
-    <% end %>
-    <div class="col-md-#{ has_projects?(@sub_projects, @siblings) ? 9 : 12}">
+    <div class="col-xs-<%= @sidebar_projects.any? ? 10 : 12 %>">
       <table class="project-table">
         <thead class="table-header fixed-header">
           <tr class="project-table__row project-table__row--header">
@@ -103,6 +81,21 @@
         </tfoot>
       </table>
     </div>
+
+    <aside class="col-xs-2 hierarchy">
+      <% if @sidebar_projects.any? %>
+        <h4>Hierarchy</h4>
+        <label>Parent:</label>
+        <% top = @project.parent ? @project.parent : @project %>
+        <%= link_to top.title, project_path(top) %>
+        <label>Sub Projects:</label>
+        <ul>
+          <% @sidebar_projects.each do |sub_project| %>
+            <li><%= link_to sub_project.title, project_path(sub_project) %></li>
+          <% end %>
+        </ul>
+      <% end %>
+    </aside>
   </div>
 
 

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -4,7 +4,8 @@
   </h1>
 
   <div class="row project-details">
-    <div class="col-md-3 sub-project">
+  <% if has_projects?(@sub_projects, @siblings) %>
+    <div class="col-md-3">
       <% if @sub_projects.any? %>
         <h4> Sub Projects </h4>
         <div>
@@ -22,7 +23,8 @@
         </div>
       <% end %>
     </div>
-    <div class="col-md-9">
+    <% end %>
+    <div class="col-md-#{ has_projects?(@sub_projects, @siblings) ? 9 : 12}">
       <table class="project-table">
         <thead class="table-header fixed-header">
           <tr class="project-table__row project-table__row--header">

--- a/app/views/stories/edit.html.erb
+++ b/app/views/stories/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <h1 class="dashboard-title-report"><%= render "shared/project_title", project: @project %></h1>
+  <h1 class="dashboard-title"><%= render "shared/project_title", project: @project %></h1>
   <% provide(:button_text, 'Save Changes') %>
   <h2 class="new-edit-title">Edit Story</h2>
 

--- a/app/views/stories/edit.html.erb
+++ b/app/views/stories/edit.html.erb
@@ -1,10 +1,10 @@
 <div class="container">
+  <h1 class="dashboard-title-report"><%= render "shared/project_title", project: @project %></h1>
   <% provide(:button_text, 'Save Changes') %>
   <h2 class="new-edit-title">Edit Story</h2>
 
   <%= render 'form', story: @story %>
 
   <hr>
-
-  <%= link_to 'Back', project_path(@project.id), id:"back", class: "button" %>
+  <%= link_to 'Back', project_path(@project), id:"back", class: "button" %>
 </div>

--- a/app/views/stories/new.html.erb
+++ b/app/views/stories/new.html.erb
@@ -1,10 +1,10 @@
 <div class="container">
+  <h1 class="dashboard-title-report"><%= render "shared/project_title", project: @project %></h1>
   <% provide(:button_text, 'Create') %>
   <h2 class="new-edit-title">Create New Story</h2>
 
   <%= render 'form', story: @story %>
-
   <hr>
 
-  <%= link_to 'Back', project_path(@project.id), id: "back", class: "button" %>
+  <%= link_to 'Back', project_path(@project), id: "back", class: "button" %>
 </div>

--- a/app/views/stories/new.html.erb
+++ b/app/views/stories/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <h1 class="dashboard-title-report"><%= render "shared/project_title", project: @project %></h1>
+  <h1 class="dashboard-title"><%= render "shared/project_title", project: @project %></h1>
   <% provide(:button_text, 'Create') %>
   <h2 class="new-edit-title">Create New Story</h2>
 

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <h1 class="dashboard-title-report"><%= render "shared/project_title", project: @project %></h1>
+  <h1 class="dashboard-title"><%= render "shared/project_title", project: @project %></h1>
 
   <%= render "shared/story", story: @story %>
   <div class="btn-group">

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -1,7 +1,9 @@
 <div class="container">
+  <h1 class="dashboard-title-report"><%= render "shared/project_title", project: @project %></h1>
+
   <%= render "shared/story", story: @story %>
   <div class="btn-group">
-    <%= link_to 'Edit', edit_project_story_path(@project.id), id:"back", class: "button" %>
-    <%= link_to 'Back', project_path(@project.id), id:"back", class: "button" %>
+    <%= link_to 'Edit', edit_project_story_path(@project), id:"back", class: "button" %>
+    <%= link_to 'Back', project_path(@project), id:"back", class: "button" %>
   </div>
 </div>

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -101,30 +101,40 @@ RSpec.describe "managing projects" do
     end.to_csv
   end
 
-  context "with sub projects" do
-    let!(:sub_project1) { FactoryBot.create(:project, parent: project) }
-    let!(:sub_project2) { FactoryBot.create(:project, parent: project) }
+  context "hierarchy sidebar" do
+    context "with sub projects" do
+      let!(:sub_project1) { FactoryBot.create(:project, parent: project) }
+      let!(:sub_project2) { FactoryBot.create(:project, parent: project) }
 
-    it "renders a sidebar with the hierarchy" do
-      visit project_path(project)
-      within ".hierarchy" do
-        expect(page).to have_selector('a', text: project.title)
-        expect(page).to have_selector('a', text: sub_project1.title)
-        expect(page).to have_selector('a', text: sub_project2.title)
+      it "renders a sidebar" do
+        visit project_path(project)
+        within "aside.hierarchy" do
+          expect(page).to have_selector('a', text: project.title)
+          expect(page).to have_selector('a', text: sub_project1.title)
+          expect(page).to have_selector('a', text: sub_project2.title)
+        end
+
+        visit project_path(sub_project1)
+        within "aside.hierarchy" do
+          expect(page).to have_selector('a', text: project.title)
+          expect(page).to have_selector('a', text: sub_project1.title)
+          expect(page).to have_selector('a', text: sub_project2.title)
+        end
+
+        visit project_path(sub_project2)
+        within "aside.hierarchy" do
+          expect(page).to have_selector('a', text: project.title)
+          expect(page).to have_selector('a', text: sub_project1.title)
+          expect(page).to have_selector('a', text: sub_project2.title)
+        end
       end
+    end
 
-      visit project_path(sub_project1)
-      within ".hierarchy" do
-        expect(page).to have_selector('a', text: project.title)
-        expect(page).to have_selector('a', text: sub_project1.title)
-        expect(page).to have_selector('a', text: sub_project2.title)
-      end
+    context "with no sub projects" do
+      it "renders no sidebar" do
+        visit project_path(project)
 
-      visit project_path(sub_project2)
-      within ".hierarchy" do
-        expect(page).to have_selector('a', text: project.title)
-        expect(page).to have_selector('a', text: sub_project1.title)
-        expect(page).to have_selector('a', text: sub_project2.title)
+        expect(page).not_to have_selector('aside.hierarchy')
       end
     end
   end

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -100,4 +100,32 @@ RSpec.describe "managing projects" do
       row["description"] = "blank!"
     end.to_csv
   end
+
+  context "with sub projects" do
+    let!(:sub_project1) { FactoryBot.create(:project, parent: project) }
+    let!(:sub_project2) { FactoryBot.create(:project, parent: project) }
+
+    it "renders a sidebar with the hierarchy" do
+      visit project_path(project)
+      within ".hierarchy" do
+        expect(page).to have_selector('a', text: project.title)
+        expect(page).to have_selector('a', text: sub_project1.title)
+        expect(page).to have_selector('a', text: sub_project2.title)
+      end
+
+      visit project_path(sub_project1)
+      within ".hierarchy" do
+        expect(page).to have_selector('a', text: project.title)
+        expect(page).to have_selector('a', text: sub_project1.title)
+        expect(page).to have_selector('a', text: sub_project2.title)
+      end
+
+      visit project_path(sub_project2)
+      within ".hierarchy" do
+        expect(page).to have_selector('a', text: project.title)
+        expect(page).to have_selector('a', text: sub_project1.title)
+        expect(page).to have_selector('a', text: sub_project2.title)
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Description:**

Refactor projects and story navigation.

- Removes the project link from the header and replaces with link to homepage.
- Shows the sub-projects in the individual project page
- Adds the breadcrumb links for the parent project in the story pages.
___

Projects page
<img width="786" alt="project_show_page" src="https://user-images.githubusercontent.com/110372/146270163-76d91b39-7d32-4667-b100-217ef88ad2a3.png">

___
Project page with sub-projects
<img width="804" alt="projects_page" src="https://user-images.githubusercontent.com/110372/146270198-d1cead00-2067-44c3-b5e7-17b8539bd06b.png">

___
Project page with stories
<img width="795" alt="sub_project_page" src="https://user-images.githubusercontent.com/110372/146270238-60bb2406-ff65-4772-a2cf-af81c8ad5275.png">

___
Stories with project breadcrumb
<img width="817" alt="Screen Shot 2021-12-16 at 03 41 34" src="https://user-images.githubusercontent.com/110372/146271341-431c78fa-b38f-4167-a75f-4568b8af15dd.png">


I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).


