### PR TITLE
Fix the footer text

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -10,6 +10,6 @@
     </h2>
   </div>
   <div>
-    <p class="txt_footer">Made with ❤ in Philadelphia and Buenos Aires</p>
+    <p class="txt_footer">Made with ❤ around the world</p>
   </div>
 </footer>


### PR DESCRIPTION
**Description:**

This closes #157 and changes the text in footer to reference no country.

<img width="609" alt="Screen Shot 2021-12-18 at 18 35 13" src="https://user-images.githubusercontent.com/11785031/146656040-aab70bd4-2198-494f-8216-d88998384500.png">

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
