### PR TITLE
Show the project status with the project name

### DIFF
--- a/app/assets/stylesheets/2-quarks/_custom_typography.scss
+++ b/app/assets/stylesheets/2-quarks/_custom_typography.scss
@@ -76,6 +76,10 @@ h4 {
   font-weight: 300;
   line-height: 40px;
   z-index: 1;
+
+  .status-badge {
+    font-size: 16px;
+  }
 }
 
 .fixed-header {

--- a/app/assets/stylesheets/3-atoms/_badges.scss
+++ b/app/assets/stylesheets/3-atoms/_badges.scss
@@ -1,12 +1,12 @@
 .status-badge {
   display: inline-block;
-  padding: 0.25em 0.4em;
+  padding: 10px 20px;
   font-weight: 700;
   line-height: 1;
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
-  border-radius: 0.25rem;
+  border-radius: 20px;
 
   &.archived {
     background-color: rgba(29,78,216,0.2);

--- a/app/assets/stylesheets/3-atoms/_badges.scss
+++ b/app/assets/stylesheets/3-atoms/_badges.scss
@@ -1,0 +1,15 @@
+.status-badge {
+  display: inline-block;
+  padding: 0.25em 0.4em;
+  font-weight: 700;
+  line-height: 1;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: 0.25rem;
+
+  &.archived {
+    background-color: rgba(29,78,216,0.2);
+    border-color: #1d4ed8;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -31,6 +31,7 @@
 @import "2-quarks/code";
 
 // 3-ATOMS
+@import "3-atoms/badges";
 @import "3-atoms/buttons";
 @import "3-atoms/forms";
 @import "3-atoms/cards";

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -23,7 +23,8 @@ class ProjectsController < ApplicationController
   end
 
   def toggle_archive
-    Project.find(params[:id]).toggle_archived!
+    @project = Project.find(params[:id])
+    @project.toggle_archived!
   end
 
   def duplicate

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -9,6 +9,7 @@
             <%= link_to project_path(project.id) do %>
               <div>
                 <h2><%= project.title %></h2>
+                <span class="status-badge <%= project.status %>"><%= project.status %></span>
               </div>
             <% end %>
             <% project.projects.each do |subproj| %>

--- a/app/views/projects/toggle_archive.js.erb
+++ b/app/views/projects/toggle_archive.js.erb
@@ -1,5 +1,9 @@
-
 (function() {
+  toggleButtonText();
+  toggleProjectStatus();
+})()
+
+function toggleButtonText() {
   let button_text = document.querySelector('#toggle_archive');
 
   if (button_text.textContent == "Archive Project") {
@@ -7,4 +11,19 @@
   } else {
     button_text.textContent = "Archive Project"
   }
-})()
+}
+
+function toggleProjectStatus() {
+  let statusBadge = document.querySelector(".status-badge");
+  let projectStatus = "<%= @project.status %>";
+
+  if (projectStatus === ""){
+    statusBadge.classList.add("hide")
+    statusBadge.textContent = ""
+  }
+  else{
+    statusBadge.classList.remove("hide")
+    statusBadge.classList.add(projectStatus)
+    statusBadge.textContent = projectStatus
+  }
+}

--- a/app/views/shared/_project_title.html.erb
+++ b/app/views/shared/_project_title.html.erb
@@ -1,3 +1,5 @@
 <% if project.parent %>
   <%= link_to project.parent.title, project_path(project.parent) %> &raquo;&nbsp;
 <% end %><%= project.title %>
+
+<span class="status-badge <%= project.status %>"><%= project.status %></span>


### PR DESCRIPTION
Description:

This closes #176 and shows the project's status with the project name so it's easy to identify archived projects.

<img width="1227" alt="Screen Shot 2022-01-05 at 16 35 17" src="https://user-images.githubusercontent.com/11785031/148278968-6128d19b-96f3-43ee-abfb-c1f58939598b.png">

It is also showing the same status bagde in the projects page: 
<img width="1219" alt="Screen Shot 2022-01-05 at 16 35 06" src="https://user-images.githubusercontent.com/11785031/148278998-5c867d11-115c-4553-bb61-5e2564f711f1.png">

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
