### PR TITLE
Update the hover states for the project cards

### DIFF
--- a/app/assets/stylesheets/3-atoms/_cards.scss
+++ b/app/assets/stylesheets/3-atoms/_cards.scss
@@ -1,11 +1,17 @@
-.project-card{
+.project-card {
   background-color: $white;
   color: $black;
   padding: 1rem;
   border: 1px solid $orange;
   display: block;
   margin: 1rem 0;
-  &:hover{
+  &:hover {
+    border: 4px solid $orange;
+  }
+  &.sub:hover {
     background-color: $orange;
+  }
+  &.sub:active {
+    background-color: #ffd633;
   }
 }

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -12,7 +12,7 @@
               </div>
             <% end %>
             <% project.projects.each do |subproj| %>
-              <%= link_to subproj.title, project_path(subproj), class: "project-card" %>
+              <%= link_to subproj.title, project_path(subproj), class: "project-card sub" %>
             <% end %>
           </div>
         </div>


### PR DESCRIPTION
This PR closes #181 . Currently when we hover over sub-projects they turn the same background color as the main project card. This is a little confusing. I consulted with Nathalie for a better user experience. She came up with this new design. I also added a click state so the user can tell when they are clicking. 

Screenshots:
Before and After:
![Screen Shot 2022-01-12 at 12 25 47 PM](https://user-images.githubusercontent.com/28625558/149191532-7002f18f-1223-42c8-81b1-4839fd969b75.png)
Before:
<img width="399" alt="Screen Shot 2022-01-12 at 12 31 52 PM" src="https://user-images.githubusercontent.com/28625558/149191708-84d23cdd-0167-468f-897e-b532e4b6cd8a.png">
After:
![Screen Shot 2022-01-12 at 12 25 32 PM](https://user-images.githubusercontent.com/28625558/149191743-68105335-b33a-4e4b-b530-d216edd1840d.png)
Before:
<img width="408" alt="Screen Shot 2022-01-12 at 12 31 56 PM" src="https://user-images.githubusercontent.com/28625558/149191796-73eb33f5-2ee1-4b27-901b-624e5b6137a9.png">
After:
![Screen Shot 2022-01-12 at 12 25 39 PM](https://user-images.githubusercontent.com/28625558/149191830-58e0709c-b516-4e16-a7c7-2a8a7b2730b7.png)



___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
