### PR TITLE
Prevent overflowing links in the story preview

### DIFF
--- a/app/assets/stylesheets/stories.scss
+++ b/app/assets/stylesheets/stories.scss
@@ -52,7 +52,7 @@
     "title preview"
     "description preview"
     "submit .";
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(2, minmax(50%, 1fr));
   grid-column-gap: 10px;
 
   #error_explanation {
@@ -76,6 +76,10 @@
     .content {
       overflow: auto;
       max-height: min(50vh, 700px);
+      // prevent long links from overflowing
+      a {
+        word-break: break-all;
+      }
     }
   }
 


### PR DESCRIPTION
**Description:**

Fixes: https://github.com/fastruby/points/issues/192

Long links stretch the with of the preview when they overflow. The input
side of the edit screen shrinks to accommodate the overflow. This is not
ideal because it becomes harder and harder to see your input as it is
reduced in size.

By using minmax function we can be sure that the input size will be at
least 50% of the parent width.

Setting a min width on the input side is not all that is required
because it still allows the long link to overflow requiring that the
user scroll from left to right on the screen to view the entire preview.

So to improve on the minmax solution we also force long links to break
when ever they reach the container boundary.

## For QA
1. Create a story
2. Make sure to include a long link such as: 
http://click.revue.email/ss/c/TzfyQfvFfgo-vTkXDZQg11ss1UDf9kKcltraveMoLkgId13tgDEYAkZth_9V0UDjXlJYGxwIQskCeZmw7nj6QNAyFM6kgMneTr-fcQT0UviQErJjWysr4ikyIabEtAc_aQJZrx9S21p8NtCE91S4QYjxBXUKPBycsIDGGoKxfnI1rv72mf6SRQgnAVEueBX3C9oXwoWPkE619D__G0rOGWXaJs8cDFKdEd-IwOaVvA8/3jk/tAw5AKjuQM-Q3_4kWlAdcw/h28/dO58uY0wnKGR-Zj3sqBfVq9SoTBjZQruGJP-NVaMgSQ
3. Make sure the edit screen still uses 50% of the page for editing and 50% of the page for previewing.

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
