### PR TITLE
Archive sub-projects when a project is archived

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -50,8 +50,7 @@ class Project < ApplicationRecord
   end
 
   def toggle_archived!
-    new_status = archived? ? nil : "archived"
-    update_column :status, new_status
+    archived? ? unarchive : archive
   end
 
   # returns all the sub-projects from its parent's project except self
@@ -78,5 +77,19 @@ class Project < ApplicationRecord
 
     last_position = parent.projects.where.not(position: nil).order(position: :asc).last&.position || 0
     self.position = last_position + 1
+  end
+
+  def archive
+    update_column :status, "archived"
+    projects.each do |sub_project|
+      sub_project.update_column :status, "archived"
+    end
+  end
+
+  def unarchive
+    update_column :status, nil
+    projects.each do |sub_project|
+      sub_project.update_column :status, nil
+    end
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -80,16 +80,10 @@ class Project < ApplicationRecord
   end
 
   def archive
-    update_column :status, "archived"
-    projects.each do |sub_project|
-      sub_project.update_column :status, "archived"
-    end
+    Project.where(id: id).or(Project.where(parent_id: id)).update_all(status: "archived")
   end
 
   def unarchive
-    update_column :status, nil
-    projects.each do |sub_project|
-      sub_project.update_column :status, nil
-    end
+    Project.where(id: id).or(Project.where(parent_id: id)).update_all(status: nil)
   end
 end

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -29,13 +29,6 @@ RSpec.describe "managing projects", js: true do
     expect(page).to have_content "Project updated!"
   end
 
-  it "allows me to archive a project" do
-    visit project_path(id: project.id)
-    click_link "Archive Project"
-    expect(page).to have_content "Unarchive Project"
-    expect(project.reload).to be_archived
-  end
-
   it "allows me to delete a project", js: false do
     visit project_path(id: project.id)
     click_link "Edit or Delete Project"
@@ -138,6 +131,22 @@ RSpec.describe "managing projects", js: true do
       click_on "Import"
       expect(project.stories.count).to be story_count
       expect(project.stories.map(&:description).join).to_not include("quick")
+    end
+  end
+
+  context "when archiving", js: true do
+    it "allows me to archive a project" do
+      visit project_path(id: project.id)
+      click_link "Archive Project"
+      expect(page).to have_content "Unarchive Project"
+      expect(project.reload).to be_archived
+    end
+
+    it "archives sub projects" do
+      sub_project = FactoryBot.create(:project, parent: project)
+      visit project_path(id: project.id)
+      click_link "Archive Project"
+      expect(sub_project.reload).to be_archived
     end
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -20,4 +20,54 @@ RSpec.describe Project, type: :model do
     expect(sub_project1.position).to eq 1
     expect(sub_project2.position).to eq 2
   end
+
+  describe "#toggle_archived!" do
+    context "when unarchived" do
+      before(:each) do
+        subject.update_column :status, nil
+      end
+
+      it "archives the project" do
+        subject.toggle_archived!
+        expect(subject.reload).to be_archived
+      end
+
+      it "archives sub projects" do
+        add_sub_project
+
+        subject.toggle_archived!
+
+        expect(subject.projects).to_not be_empty
+        subject.projects.each do |project|
+          expect(project).to be_archived
+        end
+      end
+    end
+
+    context "when archived" do
+      before(:each) do
+        subject.update_column :status, "archived"
+      end
+
+      it "unarchives the project" do
+        subject.toggle_archived!
+        expect(subject.reload).to_not be_archived
+      end
+
+      it "unarchives sub projects" do
+        add_sub_project
+
+        subject.toggle_archived!
+
+        expect(subject.projects).to_not be_empty
+        subject.projects.each do |project|
+          expect(project).to_not be_archived
+        end
+      end
+    end
+  end
+
+  def add_sub_project
+    FactoryBot.create(:project, parent: subject, status: subject.status)
+  end
 end


### PR DESCRIPTION
**Description:**

Closes: https://github.com/fastruby/points/issues/197

When we toggle a project's status it makes sense to also toggle its
sub-projects status'. This way we prevent changes to the sub-projects.

Added model and feature specs too.

** QA Steps **
1. Create a projects (parent project)
2. Add sub projects to that projects
3. Refresh screen to make sure parent project now contains sub projects.
5. Confirm for yourself that all projects are not archived.
4. Archive the parent project
5. Make sure that the new (archived) project and all the sub projects are archived.

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
