### PR TITLE
[Bugfix]: Code blocks are shown in non-monospace fonts

### DIFF
--- a/app/assets/stylesheets/1-utilities/_variables.scss
+++ b/app/assets/stylesheets/1-utilities/_variables.scss
@@ -24,6 +24,7 @@ $header_height: 90px;
 $font-lato: "Lato", "Helvetica", Arial, sans-serif;
 $font-open-sans: "Open Sans", "Helvetica", Arial, sans-serif;
 $font-maven: "Maven", "Lato", "Helvetica", Arial, sans-serif;
+$font-monospace: "Menlo", "Monaco", "Consolas", "Courier New", monospace;
 $base-font-size: 17px;
 $base-line-height: 1.4;
 

--- a/app/assets/stylesheets/2-quarks/_code.scss
+++ b/app/assets/stylesheets/2-quarks/_code.scss
@@ -1,3 +1,7 @@
-code {
-  white-space: pre;
+pre {
+  code {
+    overflow-x: scroll;
+    white-space: pre;
+    font-family: $font-monospace;
+  }
 }

--- a/app/assets/stylesheets/stories.scss
+++ b/app/assets/stylesheets/stories.scss
@@ -52,7 +52,7 @@
     "title preview"
     "description preview"
     "submit .";
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(50%, 1fr));
   grid-column-gap: 10px;
 
   #error_explanation {

--- a/app/assets/stylesheets/stories.scss
+++ b/app/assets/stylesheets/stories.scss
@@ -52,7 +52,7 @@
     "title preview"
     "description preview"
     "submit .";
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   grid-column-gap: 10px;
 
   #error_explanation {


### PR DESCRIPTION
Closes #191. Also, it might accidentally resolve #192. 

**Description:**

* adds a monospace font-family `scss` variable
* adds `overflow-x: scroll` to `code` elements
* modifies `grid-template-columns` of `.new_story` and `.edit_story` classes to use the `repeat` CSS function to avoid the code overflowing on long lines and ignore the `scroll` rule (context: https://css-tricks.com/equal-width-columns-in-css-grid-are-kinda-weird/)

**Screenshots:**
<img width="949" alt="Screen Shot 2022-01-28 at 6 46 24 PM" src="https://user-images.githubusercontent.com/70274722/151637115-8f51cf4d-cca1-4d1f-afa7-4a10a36cc943.png">

<img width="969" alt="Screen Shot 2022-01-28 at 6 47 20 PM" src="https://user-images.githubusercontent.com/70274722/151637124-7750888e-48ac-4198-a636-324a68bf8308.png">


___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
