### PR TITLE
Fix flaky sort sub project spec (WIP)

### DIFF
--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -210,4 +210,17 @@ RSpec.describe ProjectsController, type: :controller do
       end
     end
   end
+
+  describe "PATCH sort" do
+    let!(:sub_project1) { FactoryBot.create(:project, parent: project, position: 1) }
+    let!(:sub_project2) { FactoryBot.create(:project, parent: project, position: 2) }
+    let!(:sub_project3) { FactoryBot.create(:project, parent: project, position: 3) }
+
+    it "changes the positions of the sub-projects" do
+      patch :sort, params: {id: project.id, project: [sub_project3.id, sub_project1.id, sub_project2.id]}
+      expect(sub_project3.reload.position).to eq 1
+      expect(sub_project1.reload.position).to eq 2
+      expect(sub_project2.reload.position).to eq 3
+    end
+  end
 end

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -21,15 +21,9 @@ RSpec.describe "home specs" do
         first = find("a", text: sub_project1.title)
         last = find("a", text: sub_project3.title)
 
-        last.drag_to(first, html5: false)
-
-        # we need some `sleep` calls around the dragging because it uses a javascript
-        # delay internally
-        sleep(2)
+        last.drag_to(first, delay: 0, html5: false)
 
         expect(page).not_to have_selector("#project_#{project.id}.project-card.sorting")
-
-        sleep(2)
 
         expect(sub_project1.reload.position).to eq 2
         expect(sub_project2.reload.position).to eq 3

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe "home specs" do
         first = find("a", text: sub_project1.title)
         last = find("a", text: sub_project3.title)
 
+        # The use expect_any_instance_of is discouraged by the RSpec team, but the drag_to
+        # method is not always consistent on the distance it drags elements and the order
+        # is not always the expected. So I'm using expect_any_instance_of on purpose here.
         expect_any_instance_of(ProjectsController).to receive(:sort)
 
         last.drag_to(first, delay: 0, html5: false)

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -21,13 +21,11 @@ RSpec.describe "home specs" do
         first = find("a", text: sub_project1.title)
         last = find("a", text: sub_project3.title)
 
+        expect_any_instance_of(ProjectsController).to receive(:sort)
+
         last.drag_to(first, delay: 0, html5: false)
 
         expect(page).not_to have_selector("#project_#{project.id}.project-card.sorting")
-
-        expect(sub_project1.reload.position).to eq 2
-        expect(sub_project2.reload.position).to eq 3
-        expect(sub_project3.reload.position).to eq 1
       end
     end
   end


### PR DESCRIPTION
**Description:**

Seems like the drag_to capybara method is not that consistent/stable and it doesn't drop elements in the same position (it gets the center of both elements and moves things with some delay and the sortable javascript needs things to be move a bit more)

Instead of checking the exact order, changed the test to verify the call to the `sort` action was done and then I added a controller test for the sort action.

I re-ran the tests like 5 times and it's been green on all runs

Closes #204 

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
