### PR TITLE
Allow picking whick sub-projects to clone when cloning

### DIFF
--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -1,4 +1,4 @@
-document.addEventListener("turbolinks:load", function() {
+document.addEventListener("turbolinks:load", function () {
   $("input[name='stories[]']").click(() => {
     const selected = $("input[name='stories[]']:checked");
 
@@ -12,74 +12,112 @@ document.addEventListener("turbolinks:load", function() {
       $("#bulk_delete")
         .text("Bulk Delete")
         .attr("aria-disabled", "true")
-        .prop("disabled", true)
+        .prop("disabled", true);
     }
-  })
+  });
 
   $(".import-export-header").click(function () {
     $(this).children(".rotate").toggleClass("left");
-  })
+  });
 
   $("#bulk_delete").click((event) => {
-    let stories_ids = []
+    let stories_ids = [];
     $("input[name='stories[]']:checked").each((_, checkbox) => {
-      stories_ids.push($(checkbox).val())
-    })
+      stories_ids.push($(checkbox).val());
+    });
 
     $(event.target)
       .text("Bulk Delete")
       .attr("aria-disabled", "true")
-      .prop("disabled", true)
+      .prop("disabled", true);
 
-    let token = $("meta[name='csrf-token']").attr("content")
+    let token = $("meta[name='csrf-token']").attr("content");
     $.ajaxSetup({
       beforeSend: function (xhr) {
         xhr.setRequestHeader("X-CSRF-Token", token);
-      }
+      },
     });
 
     $.ajax({
       url: "/stories/bulk_destroy",
-      data: {ids: stories_ids},
+      data: { ids: stories_ids },
       type: "POST",
       success: () => {
         $(stories_ids).each((_, id) => {
-          console.log(id)
+          console.log(id);
           $("#story_" + id).remove();
-        })
+        });
       },
       error: (result) => {
-        console.log("There was an error destroying the stories")
+        console.log("There was an error destroying the stories");
+      },
+    });
+  });
+
+  // bind select/unselect all when cloning projects
+  document.querySelectorAll("#select-all, #unselect-all").forEach((button) => {
+    const setCheck = button.id === "select-all" ? true : false;
+
+    button.addEventListener("click", (e) => {
+      e.preventDefault();
+      toggleCloneSubProjects(setCheck);
+    });
+  });
+
+  // unselect all if clone is not a parent
+  const projectCloneParent = document.getElementById("project_parent_id");
+  if (projectCloneParent) {
+    projectCloneParent.addEventListener("change", (e) => {
+      const classes = document.getElementById(
+        "sub-projects-to-clone"
+      ).classList;
+      if (projectCloneParent.value !== "") {
+        classes.add("is-not-parent");
+      } else {
+        classes.remove("is-not-parent");
       }
-    })
-  })
-})
+    });
+  }
+});
 
 window.addEventListener("load", () => {
-  const links = document.querySelectorAll(".project-table__row--story a.delete");
+  const links = document.querySelectorAll(
+    ".project-table__row--story a.delete"
+  );
   links.forEach((element) => {
     element.addEventListener("ajax:success", () => {
-      document.getElementById(`story_${element.dataset.storyId}`).remove()
+      document.getElementById(`story_${element.dataset.storyId}`).remove();
       console.log("The story was deleted.");
     });
   });
 });
 
 const filterStories = () => {
-  const searchTerm = document.getElementById("title_contains").value.toLowerCase().trim();
+  const searchTerm = document
+    .getElementById("title_contains")
+    .value.toLowerCase()
+    .trim();
   if (searchTerm.length == 0) {
     $("#stories").sortable("enable");
   } else {
     $("#stories").sortable("disable");
   }
 
-  document.querySelectorAll("#stories tr").forEach(function(element) {
-    const cl = element.classList
-    const storyTitle = element.querySelector("td:first-child").innerText.toLowerCase()
+  document.querySelectorAll("#stories tr").forEach(function (element) {
+    const cl = element.classList;
+    const storyTitle = element
+      .querySelector("td:first-child")
+      .innerText.toLowerCase();
     if (storyTitle.includes(searchTerm)) {
-      cl.remove("hidden")
+      cl.remove("hidden");
     } else {
-      cl.add("hidden")
+      cl.add("hidden");
     }
-  })
+  });
 };
+
+function toggleCloneSubProjects(value) {
+  document
+    .querySelectorAll("#sub-projects-to-clone input[type='checkbox']")
+    .forEach((el) => (el.checked = value));
+}

--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -66,15 +66,14 @@ document.addEventListener("turbolinks:load", function () {
 
   // unselect all if clone is not a parent
   const projectCloneParent = document.getElementById("project_parent_id");
-  if (projectCloneParent) {
+  const subProjects = document.getElementById("sub-projects-to-clone");
+
+  if (projectCloneParent && subProjects) {
     projectCloneParent.addEventListener("change", (e) => {
-      const classes = document.getElementById(
-        "sub-projects-to-clone"
-      ).classList;
       if (projectCloneParent.value !== "") {
-        classes.add("is-not-parent");
+        subProjects.classList.add("is-not-parent");
       } else {
-        classes.remove("is-not-parent");
+        subProjects.classList.remove("is-not-parent");
       }
     });
   }

--- a/app/assets/stylesheets/project.scss
+++ b/app/assets/stylesheets/project.scss
@@ -193,29 +193,62 @@
   background: none;
   border: none;
   padding: 8px;
-  color: #F70A7C;
+  color: #f70a7c;
 
   i {
     position: relative;
     border-radius: 50%;
     padding: 5px;
     opacity: 0;
-    transition: transform 0.5s,
-                opacity 0.5s;
-    transform: translateX(-100%)
+    transition: transform 0.5s, opacity 0.5s;
+    transform: translateX(-100%);
   }
 
   &:hover {
     i {
       opacity: 1;
-      transform: translateX(0)
+      transform: translateX(0);
     }
   }
 
   &:active {
     i {
-      background: #F70A7C;
+      background: #f70a7c;
       color: white;
+    }
+  }
+}
+
+#sub-projects-to-clone {
+  margin-bottom: 2rem;
+  .no-parent-disclaimer {
+    display: none;
+    font-weight: bold;
+  }
+  button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    margin-right: 1rem;
+    margin-top: 0.2rem;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+  h4 {
+    margin-bottom: 0.5rem;
+  }
+  label {
+    margin-top: 0.2rem;
+  }
+  &.is-not-parent {
+    p,
+    button,
+    label {
+      display: none;
+    }
+    .no-parent-disclaimer {
+      display: block;
     }
   }
 }

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -41,7 +41,9 @@ class ProjectsController < ApplicationController
     original = Project.includes(stories: :estimates).find(params[:id])
     clone = Project.create(clone_params)
     original.clone_stories_into(clone)
-    original.clone_projects_into(clone) if clone.parent.nil? && original.projects
+    if clone.parent.nil? && original.projects
+      original.clone_projects_into(clone, only: params[:sub_project_ids])
+    end
 
     flash[:success] = "Project cloned!"
     redirect_to "/projects/#{clone.id}"

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -63,8 +63,11 @@ class Project < ApplicationRecord
     stories.each { |story| clone.stories.create(story.dup.attributes) }
   end
 
-  def clone_projects_into(clone)
-    projects.each do |sub_project|
+  def clone_projects_into(clone, only: nil)
+    return if only == []
+
+    to_clone = only.nil? ? projects : projects.where(id: only)
+    to_clone.each do |sub_project|
       sub_project_clone = clone.projects.create(sub_project.dup.attributes)
       sub_project.clone_stories_into(sub_project_clone)
     end

--- a/app/views/projects/new_clone.html.erb
+++ b/app/views/projects/new_clone.html.erb
@@ -12,6 +12,20 @@
       <%= f.select :parent_id, options_from_collection_for_select(Project.active.parents, :id, :title, selected: @original.parent_id), include_blank: "None" %>
     </div>
 
+    <div id="sub-projects-to-clone">
+      <h4>Sub-projects to clone</h4>
+      <p>Select which sub-projects will be cloned</p>
+      <% @original.projects.each do |sub| %>
+        <label>
+          <%= check_box_tag "sub_project_ids[]", sub.id, checked: true %>
+          <%= sub.title %>
+        </label>
+      <% end %>
+      <%= button_tag "Select all", id: "select-all" %>
+      <%= button_tag "Unselect all", id: "unselect-all" %>
+      <p class="no-parent-disclaimer">Can't clone sub-projects if it's not a parent project</p>
+    </div>
+
     <div class="actions">
       <%= button_tag "Clone", class: "button", type: "submit" %>
       <%= link_to 'Back', project_path(@original.id), id:"back", class: "button" %>

--- a/app/views/projects/new_clone.html.erb
+++ b/app/views/projects/new_clone.html.erb
@@ -12,19 +12,21 @@
       <%= f.select :parent_id, options_from_collection_for_select(Project.active.parents, :id, :title, selected: @original.parent_id), include_blank: "None" %>
     </div>
 
-    <div id="sub-projects-to-clone">
-      <h4>Sub-projects to clone</h4>
-      <p>Select which sub-projects will be cloned</p>
-      <% @original.projects.each do |sub| %>
-        <label>
-          <%= check_box_tag "sub_project_ids[]", sub.id, checked: true %>
-          <%= sub.title %>
-        </label>
-      <% end %>
-      <%= button_tag "Select all", id: "select-all" %>
-      <%= button_tag "Unselect all", id: "unselect-all" %>
-      <p class="no-parent-disclaimer">Can't clone sub-projects if it's not a parent project</p>
-    </div>
+    <% if @original.projects.any? %>
+      <div id="sub-projects-to-clone">
+        <h4>Sub-projects to clone</h4>
+        <p>Select which sub-projects will be cloned</p>
+        <% @original.projects.each do |sub| %>
+          <label>
+            <%= check_box_tag "sub_project_ids[]", sub.id, checked: true %>
+            <%= sub.title %>
+          </label>
+        <% end %>
+        <%= button_tag "Select all", id: "select-all" %>
+        <%= button_tag "Unselect all", id: "unselect-all" %>
+        <p class="no-parent-disclaimer">Can't clone sub-projects if it's not a parent project</p>
+      </div>
+    <% end %>
 
     <div class="actions">
       <%= button_tag "Clone", class: "button", type: "submit" %>

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -188,6 +188,17 @@ RSpec.describe ProjectsController, type: :controller do
         last_project = other_project.projects.reload.last
         expect(last_project.parent).to eq(other_project)
       end
+
+      it "ignores sub-projects if not cloned as a parent" do
+        other_project = FactoryBot.create(:project)
+
+        expect {
+          post :clone, params: {id: project.id, project: {title: "New title", parent_id: other_project.id}, sub_project_ids: [sub_project.id]}
+        }.to change(Project, :count).by(1)
+
+        last_project = other_project.projects.reload.last
+        expect(last_project.projects).to be_empty
+      end
     end
 
     context "with stories" do


### PR DESCRIPTION
**Description:**

This PR adds the option to select which sub projects will be cloned when cloning a project.

One thing to notice: when cloning a project as a sub-project (picking a parent other than None), the option to clone sub-projects is disabled, since we don't allow nested sub-projects.

With sub-projects:
![image](https://user-images.githubusercontent.com/188464/152167179-837c8517-0d05-48f6-ae7b-8bf8c8b21462.png)

If picking a parent:
![image](https://user-images.githubusercontent.com/188464/152167253-cb3f3131-8b9a-4a13-9336-c7922adf139e.png)

With no sub-projects:
![image](https://user-images.githubusercontent.com/188464/152167317-96c8cc12-e601-4486-96cf-dc61b1bed68e.png)

Closes #187
___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
