### PR TITLE
Use js response to delete single stories

### DIFF
--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -55,16 +55,6 @@ document.addEventListener("turbolinks:load", function() {
   })
 })
 
-window.addEventListener("load", () => {
-  const links = document.querySelectorAll(".project-table__row--story a.delete");
-  links.forEach((element) => {
-    element.addEventListener("ajax:success", () => {
-      document.getElementById(`story_${element.dataset.storyId}`).remove()
-      console.log("The story was deleted.");
-    });
-  });
-});
-
 const filterStories = () => {
   const searchTerm = document.getElementById("title_contains").value.toLowerCase().trim();
   if (searchTerm.length == 0) {

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -66,7 +66,7 @@
                           </div>
                         </div>
                       <% end %>
-                      <%= link_to project_story_path(@project.id, story, format: "json"), method: "delete",  data: { confirm: 'Are you sure?', story_id: story.id }, class: "delete magenta", remote: true, title: "Delete" do %>
+                      <%= link_to project_story_path(@project.id, story), method: "delete",  data: { confirm: 'Are you sure?', story_id: story.id }, class: "delete magenta", remote: true, title: "Delete" do %>
                         <i class="fa fa-trash-o"></i>
                         <span>Delete</span>
                       <% end %>

--- a/app/views/stories/destroy.js.erb
+++ b/app/views/stories/destroy.js.erb
@@ -1,0 +1,4 @@
+function(){}
+  document.getElementById(`story_<%= @story.id %>`).remove()
+  console.log("The story was deleted.");
+}()

--- a/app/views/stories/destroy.js.erb
+++ b/app/views/stories/destroy.js.erb
@@ -1,4 +1,3 @@
 function(){}
   document.getElementById(`story_<%= @story.id %>`).remove()
-  console.log("The story was deleted.");
 }()


### PR DESCRIPTION
**Description:**

This PR fixes an issue when deleting stories after pressing the `back` button of the browser. I changed the button to trigger a JS request instead of JSON so we can responde with the js to delete the row and not depend on the event listener.

I can't add a test to ensure this won't be broken, this since the failure happens when pressing the back button and it's not clear how to automate that in a test.

Closes #207 

**How to QA**

- Got to a project with stories
- Click on a story title to go to another screen
- Click back in the browser to go back to the list of stories
- Try deleting one story

Before this fix, the row was not removed because going back in the history broke the event listeners, you had to refresh the page to update the list.

Not it should remove the row as expected.

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
