### PR TITLE
Fix sorting stories and add test

### DIFF
--- a/app/assets/javascripts/sortable_list.js
+++ b/app/assets/javascripts/sortable_list.js
@@ -2,13 +2,13 @@ document.addEventListener("turbolinks:load", function () {
   $("#stories, .sortable-projects").sortable({
     update: function (e, ui) {
       const parent = ui.item[0].closest("div.project-card, .project-table");
-      if (parent) parent.classList.add("sorting");
+      parent.classList.add("sorting");
       Rails.ajax({
         type: "PATCH",
         url: this.dataset.url,
         data: $(this).sortable("serialize"),
         complete: () => {
-          if (parent) parent.classList.remove("sorting");
+          parent.classList.remove("sorting");
         },
       });
     },

--- a/app/assets/javascripts/sortable_list.js
+++ b/app/assets/javascripts/sortable_list.js
@@ -1,14 +1,14 @@
 document.addEventListener("turbolinks:load", function () {
   $("#stories, .sortable-projects").sortable({
     update: function (e, ui) {
-      const project = ui.item[0].closest("div.project-card");
-      project.classList.add("sorting");
+      const parent = ui.item[0].closest("div.project-card, .project-table");
+      if (parent) parent.classList.add("sorting");
       Rails.ajax({
         type: "PATCH",
         url: this.dataset.url,
         data: $(this).sortable("serialize"),
         complete: () => {
-          project.classList.remove("sorting");
+          if (parent) parent.classList.remove("sorting");
         },
       });
     },

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe "managing stories", js: true do
 
     last.drag_to(first, delay: 0, html5: false)
 
-    sleep(0.1)
+    sleep(1)
 
     expect(page).not_to have_selector(".project-table.sorting")
   end

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -195,4 +195,25 @@ RSpec.describe "managing stories", js: true do
       expect(find("tr:nth-child(3)")).to have_text story3.title
     end
   end
+
+  it "allows sorting stories", js: true do
+    FactoryBot.create(:story, project: project)
+    story3 = FactoryBot.create(:story, project: project)
+
+    visit project_path(project)
+
+    first = find(".project-table__cell", text: story.title)
+    last = find(".project-table__cell", text: story3.title)
+
+    # The use expect_any_instance_of is discouraged by the RSpec team, but the drag_to
+    # method is not always consistent on the distance it drags elements and the order
+    # is not always the expected. So I'm using expect_any_instance_of on purpose here.
+    expect_any_instance_of(ProjectsController).to receive(:sort_stories)
+
+    last.drag_to(first, delay: 0, html5: false)
+
+    sleep(0.1)
+
+    expect(page).not_to have_selector(".project-table.sorting")
+  end
 end


### PR DESCRIPTION
**Description:**

This fixes a regresion introduced by https://github.com/fastruby/points/pull/182 causing https://github.com/fastruby/points/issues/210.

I update the JS code to prevent the error and also added a test.

Closes #210 

This is kinda high priority since it's currently blocking some things we are working on.

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
