### PR TITLE
correct project status label upon archive/unarchive

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -31,6 +31,7 @@ class ProjectsController < ApplicationController
   def toggle_archive
     @project = Project.find(params[:id])
     @project.toggle_archived!
+    @project.reload
   end
 
   def new_clone

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -144,6 +144,22 @@ RSpec.describe ProjectsController, type: :controller do
     end
   end
 
+  describe "#toggle_archive" do
+    context "should set the status of the project to" do
+      it "archived when it is unarchived" do
+        put :toggle_archive, params: {id: project.id}, xhr: true
+        project.reload
+        expect(assigns[:project].status).to eq(project.status)
+      end
+
+      it "nil when it is archived" do
+        put :toggle_archive, params: {id: archived_project.id}, xhr: true
+        archived_project.reload
+        expect(assigns[:project].status).to eq(archived_project.status)
+      end
+    end
+  end
+
   describe "cloning" do
     it "redirects to cloned project" do
       expect {

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "managing projects", js: true do
     accept_confirm do
       click_link "Delete Project"
     end
-    expect(page).not_to have_content 'Edit or Delete Project'
+    expect(page).not_to have_content "Edit or Delete Project"
     expect(Project.count).to eq 0
   end
 


### PR DESCRIPTION
This PR closes #214 

**Description:**

The archive / unarchive is working as expected. Although the js template was using the older instance variable @project while the object was updated. The PR reload the instance variable and added the spec for the method `toggle_archive` as it was missing.

Also while creating the commit, the rubocop was failing in a file that is not contextual to this issue, but applied the fix and pushed that file as well. This is the file `spec/features/projects_manage_spec.rb`
___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
