### PR TITLE
correct project status label upon archive/unarchive

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -31,7 +31,6 @@ class ProjectsController < ApplicationController
   def toggle_archive
     @project = Project.find(params[:id])
     @project.toggle_archived!
-    @project.reload
   end
 
   def new_clone

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -31,6 +31,7 @@ class ProjectsController < ApplicationController
   def toggle_archive
     @project = Project.find(params[:id])
     @project.toggle_archived!
+    @project.reload
   end
 
   def new_clone

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -84,9 +84,11 @@ class Project < ApplicationRecord
 
   def archive
     Project.where(id: id).or(Project.where(parent_id: id)).update_all(status: "archived")
+    self.status = "archived"
   end
 
   def unarchive
     Project.where(id: id).or(Project.where(parent_id: id)).update_all(status: nil)
+    self.status = nil
   end
 end

--- a/app/views/shared/_project_title.html.erb
+++ b/app/views/shared/_project_title.html.erb
@@ -19,6 +19,4 @@
   <%= project.title %>
 <% end %>
 
-<% if project.archived? %>
-  <span class="status-badge <%= project.status %>"><%= project.status %></span>
-<% end %>
+<span class="status-badge <%= project.status %> <%= "hide" if project.status == nil %>"><%= project.status %></span>

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -148,14 +148,12 @@ RSpec.describe ProjectsController, type: :controller do
     context "should set the status of the project to" do
       it "archived when it is unarchived" do
         put :toggle_archive, params: {id: project.id}, xhr: true
-        project.reload
-        expect(assigns[:project].status).to eq(project.status)
+        expect(assigns[:project]).to be_archived
       end
 
       it "nil when it is archived" do
         put :toggle_archive, params: {id: archived_project.id}, xhr: true
-        archived_project.reload
-        expect(assigns[:project].status).to eq(archived_project.status)
+        expect(assigns[:project]).not_to be_archived
       end
     end
   end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -144,6 +144,22 @@ RSpec.describe ProjectsController, type: :controller do
     end
   end
 
+  describe "#toggle_archive" do
+    context "should set the status of the project to" do
+      it "archived when it is unarchived" do
+        put :toggle_archive, params: {id: project.id}, xhr: true
+        project.reload
+        expect(assigns[:project].status).to eq(project.status)
+      end
+
+      it "nil when it is archived" do
+        put :toggle_archive, params: {id: archived_project.id}, xhr: true
+        archived_project.reload
+        expect(assigns[:project].status).to eq(archived_project.status)
+      end
+    end
+  end
+
   describe "cloning" do
     it "redirects to cloned project" do
       expect {

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -152,6 +152,7 @@ RSpec.describe "managing projects", js: true do
       visit project_path(id: project.id)
       click_link "Archive Project"
       expect(page).to have_content "Unarchive Project"
+      expect(page).to have_content "archived"
       expect(project.reload).to be_archived
     end
 
@@ -160,6 +161,16 @@ RSpec.describe "managing projects", js: true do
       visit project_path(id: project.id)
       click_link "Archive Project"
       expect(sub_project.reload).to be_archived
+    end
+  end
+
+  context "when unarchiving", js: true do
+    it "allows me to unarchive a project" do
+      project.toggle_archived!
+      visit project_path(id: project.id)
+      click_link "Unarchive Project"
+      expect(page).to have_content "Archive Project"
+      expect(project.reload).not_to be_archived
     end
   end
 


### PR DESCRIPTION
This PR closes #214 and #238

**Description**:

The archive / unarchive is working as expected. Although the js template was using the older instance variable `@project` while the object was updated. The PR reload the instance variable and added the spec for the method toggle_archive as it was missing.

Also while creating the commit, the rubocop was failing in a file that is not contextual to this issue, but applied the fix and pushed that file as well. This is the file `spec/features/projects_manage_spec.rb`


jira link https://ombulabs.atlassian.net/browse/DT-221