### PR TITLE
Issue #225 - fixes order of sub projects on action plan page

### DIFF
--- a/app/controllers/action_plans_controller.rb
+++ b/app/controllers/action_plans_controller.rb
@@ -4,6 +4,6 @@ class ActionPlansController < ApplicationController
   def show
     @project = Project.find(params[:project_id])
     @project_stories = @project.stories.by_position
-    @children = Project.with_ordered_stories(@project.id)
+    @children = Project.sub_projects_with_ordered_stories(@project.id)
   end
 end

--- a/app/controllers/action_plans_controller.rb
+++ b/app/controllers/action_plans_controller.rb
@@ -4,9 +4,6 @@ class ActionPlansController < ApplicationController
   def show
     @project = Project.find(params[:project_id])
     @project_stories = @project.stories.by_position
-    @children =
-      Project.where(parent_id: @project.id)
-        .includes(:stories).references(:stories)
-        .order("stories.position ASC NULLS FIRST")
+    @children = Project.with_ordered_stories(@project.id)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -12,7 +12,7 @@ class Project < ApplicationRecord
 
   scope :active, -> { where.not(status: "archived").or(where(status: nil)) }
   scope :parents, -> { where(parent: nil) }
-  scope :with_ordered_stories, ->(project_id) {
+  scope :sub_projects_with_ordered_stories, ->(project_id) {
     where(parent_id: project_id)
       .includes(:stories).references(:stories)
       .order("projects.position ASC, stories.position ASC NULLS FIRST")

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -12,6 +12,11 @@ class Project < ApplicationRecord
 
   scope :active, -> { where.not(status: "archived").or(where(status: nil)) }
   scope :parents, -> { where(parent: nil) }
+  scope :with_ordered_stories, ->(project_id) {
+    where(parent_id: project_id)
+      .includes(:stories).references(:stories)
+      .order("projects.position ASC, stories.position ASC NULLS FIRST")
+  }
 
   def best_estimate_total
     stories.includes(:estimates).sum(&:best_estimate_average)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -21,16 +21,28 @@ RSpec.describe Project, type: :model do
     expect(sub_project2.position).to eq 2
   end
 
-  describe ".with_ordered_stories" do
+  describe ".with_ordered_descendents" do
     it "orders sub projects properly" do
       parent = FactoryBot.create(:project)
-      sub_project1 = FactoryBot.create(:project, parent: parent)
-      FactoryBot.create(:story, project: sub_project1, position: 2)
-      sub_project2 = FactoryBot.create(:project, parent: parent)
-      FactoryBot.create(:story, project: sub_project2, position: 1)
+      sub_project1 = FactoryBot.create(:project, parent: parent, position: 2)
+      story_5 = FactoryBot.create(:story, project: sub_project1, position: 2)
+      story_4 = FactoryBot.create(:story, project: sub_project1, position: 1)
+      story_6 = FactoryBot.create(:story, project: sub_project1, position: 3)
+      sub_project2 = FactoryBot.create(:project, parent: parent, position: 1)
+      story_3 = FactoryBot.create(:story, project: sub_project2, position: 3)
+      story_1 = FactoryBot.create(:story, project: sub_project2, position: 1)
+      story_2 = FactoryBot.create(:story, project: sub_project2, position: 2)
+      sub_projects = Project.sub_projects_with_ordered_stories(parent.id)
 
-      results = Project.with_ordered_stories(parent.id)
-      expect(results[0].id).to eq sub_project1.id
+      expect(sub_projects.count).to eq 2
+      expect(sub_projects[0].id).to eq sub_project2.id
+      expect(sub_projects[0].stories[0].id).to eq story_1.id
+      expect(sub_projects[0].stories[1].id).to eq story_2.id
+      expect(sub_projects[0].stories[2].id).to eq story_3.id
+      expect(sub_projects[1].id).to eq sub_project1.id
+      expect(sub_projects[1].stories[0].id).to eq story_4.id
+      expect(sub_projects[1].stories[1].id).to eq story_5.id
+      expect(sub_projects[1].stories[2].id).to eq story_6.id
     end
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -21,6 +21,19 @@ RSpec.describe Project, type: :model do
     expect(sub_project2.position).to eq 2
   end
 
+  describe ".with_ordered_stories" do
+    it "orders sub projects properly" do
+      parent = FactoryBot.create(:project)
+      sub_project1 = FactoryBot.create(:project, parent: parent)
+      FactoryBot.create(:story, project: sub_project1, position: 2)
+      sub_project2 = FactoryBot.create(:project, parent: parent)
+      FactoryBot.create(:story, project: sub_project2, position: 1)
+
+      results = Project.with_ordered_stories(parent.id)
+      expect(results[0].id).to eq sub_project1.id
+    end
+  end
+
   describe "#toggle_archived!" do
     context "when unarchived" do
       before(:each) do


### PR DESCRIPTION
Closes #225

**Description:**

Sub projects on the action plan page are ordered by the position values of their stories. This throws the order of projects off - so we needed to add the project position to the order call.

** What I did **

- Move the project query from the controller to a scope on the Project model
- Write a test for the scope that fails
- Fix the scope.

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).


jira link https://ombulabs.atlassian.net/browse/DT-219