### PR TITLE
Fix for bug #214 - project archive label falls out of synch

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -31,6 +31,8 @@ class ProjectsController < ApplicationController
   def toggle_archive
     @project = Project.find(params[:id])
     @project.toggle_archived!
+
+    redirect_to @project
   end
 
   def new_clone

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -107,7 +107,7 @@
       <%= link_to 'Add Sub-Project', project_new_sub_project_path(@project.id), id:"subproject", class: "button magenta" %>
     <% end %>
     <%= link_to 'Clone Project', new_clone_project_path(@project.id), class: "button magenta" %>
-    <%= link_to "#{@project.archived? ? 'Unarchive' : 'Archive'} Project", toggle_archive_project_path(@project.id), method: "patch", id: "toggle_archive", class: "button magenta", remote: true %>
+    <%= link_to "#{@project.archived? ? 'Unarchive' : 'Archive'} Project", toggle_archive_project_path(@project.id), method: "patch", id: "toggle_archive", class: "button magenta" %>
     <%= link_to "Generate Action Plan", project_action_plan_path(@project.id), class: "button" %>
     <% if current_user.admin? %>
       <%= link_to "View Report", project_report_path(@project.id), class: "button"  %>


### PR DESCRIPTION
Closes #214

**Description:**

Clicking project archive fired a remote call to change the project status but did not update the label reliably.

- remove remote flag and cause a full refresh on state change
___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
