### PR TITLE
Closes #189 - fix code of conduct link in the PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -7,4 +7,4 @@ If changes to the UI are made, please include screenshots of the before and afte
 
 ___
 
-I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/pull_request_template.md).
+I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Closes #189

**Description:**

Fixes the link to the code of conduct in the PR template

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).
