### PR TITLE
Add basic styles for markdown components

### DIFF
--- a/app/assets/stylesheets/stories.scss
+++ b/app/assets/stylesheets/stories.scss
@@ -40,6 +40,26 @@
   overflow: auto;
 }
 
+.story-description em {
+  font-style: italic;
+}
+
+.story-description strong {
+  font-weight: bold;
+}
+
+.story-description ul {
+  padding-top: 1em;
+  padding-bottom: 1em;
+  list-style-position: inside;
+  list-style-type: circle;
+}
+
+.modal .story-description p {
+  overflow: auto;
+  margin-bottom: 1.5em;
+}
+
 .modal p {
   padding-bottom: 1.3em;
 }
@@ -90,6 +110,25 @@
     // prevent long links from overflowing
     a {
       word-break: break-all;
+    }
+
+    em {
+      font-style: italic;
+    }
+
+    strong {
+      font-weight: bold;
+    }
+
+    ul {
+      padding-top: 1em;
+      padding-bottom: 1em;
+      list-style-position: inside;
+      list-style-type: circle;
+    }
+
+    p {
+      margin-bottom: 1em;
     }
   }
 

--- a/app/assets/stylesheets/stories.scss
+++ b/app/assets/stylesheets/stories.scss
@@ -10,11 +10,25 @@
   word-break: break-all;
 }
 
-.story-description, .extra-info {
+.story-description, .extra-info, .story_preview {
   margin-bottom: 25px;
   font-size: 15px;
   p{
     margin-top: 1em;
+  }
+  em {
+    font-style: italic;
+  }
+
+  strong {
+    font-weight: bold;
+  }
+
+  ul {
+    padding-top: 1em;
+    padding-bottom: 1em;
+    list-style-position: inside;
+    list-style-type: circle;
   }
 }
 
@@ -38,27 +52,9 @@
 
 .modal .story-description p {
   overflow: auto;
-}
-
-.story-description em {
-  font-style: italic;
-}
-
-.story-description strong {
-  font-weight: bold;
-}
-
-.story-description ul {
-  padding-top: 1em;
-  padding-bottom: 1em;
-  list-style-position: inside;
-  list-style-type: circle;
-}
-
-.modal .story-description p {
-  overflow: auto;
   margin-bottom: 1.5em;
 }
+
 
 .modal p {
   padding-bottom: 1.3em;
@@ -110,25 +106,6 @@
     // prevent long links from overflowing
     a {
       word-break: break-all;
-    }
-
-    em {
-      font-style: italic;
-    }
-
-    strong {
-      font-weight: bold;
-    }
-
-    ul {
-      padding-top: 1em;
-      padding-bottom: 1em;
-      list-style-position: inside;
-      list-style-type: circle;
-    }
-
-    p {
-      margin-bottom: 1em;
     }
   }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
   OPTIONS = {
-    filter_html: true,
+    hard_wrap: true,
     link_attributes: {rel: "nofollow", target: "_blank"},
     no_intra_emphasis: true
   }.freeze


### PR DESCRIPTION
Closes #220

Closes #221 

Closes #222 

**Description:**

Redcarpet converts markdown to markup but our css reset removes all styling from the result.

<img width="870" alt="Screen Shot 2022-03-10 at 3 04 17 PM" src="https://user-images.githubusercontent.com/607860/157747347-342e9124-863f-44d2-a69d-77f6d3d40506.png">

Added styles for italics, bold, and lists on the preview:

<img width="844" alt="Screen Shot 2022-03-10 at 3 03 58 PM" src="https://user-images.githubusercontent.com/607860/157747371-e2df007c-786d-4100-930e-1668ee04220e.png">

...and on the story detail page:

<img width="305" alt="Screen Shot 2022-03-10 at 3 03 39 PM" src="https://user-images.githubusercontent.com/607860/157747451-b6be2509-d2d7-444c-a077-f7f6dbd66949.png">



___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).


jira link https://ombulabs.atlassian.net/browse/DT-215