### PR TITLE
Prevent layout from shifting when projects are hovered in lists

### DIFF
--- a/app/assets/stylesheets/3-atoms/_cards.scss
+++ b/app/assets/stylesheets/3-atoms/_cards.scss
@@ -6,7 +6,7 @@
   display: block;
   margin: 1rem 0;
   &:hover {
-    border: 4px solid $orange;
+    box-shadow: 0px 0px 6px $orange;
   }
   &.sub:hover {
     background-color: $orange;


### PR DESCRIPTION
Closes #186 

**Description:**

The projects on the project list page change the border while hovering, making them taller, causing a layout shift.

Use a a box-shadow rather than a border to style these to prevent layout shifts.
___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).

jira link https://ombulabs.atlassian.net/browse/DT-214