### PR TITLE
Add extra information field to stories

### DIFF
--- a/app/assets/javascripts/stories.js
+++ b/app/assets/javascripts/stories.js
@@ -1,18 +1,23 @@
 document.addEventListener("input", (e) => {
-  if (e.target.classList.contains("story-description")) {
-    const desc = e.target;
-    const form = desc.closest("form");
-    const preview = form.querySelector(".story_preview .content");
-    if (preview) {
-      Rails.ajax({
-        type: "POST",
-        url: "/stories/render_markdown",
-        data: `markdown=${encodeURIComponent(desc.value)}`,
-        dataType: "text",
-        success: (response) => {
-          preview.innerHTML = response;
-        },
-      });
+  function preview_setup(text_area_class, preview_class) {
+    if (e.target.classList.contains(text_area_class)) {
+      const desc = e.target;
+      const form = desc.closest("form");
+      const preview = form.querySelector(preview_class  + " .content");
+      if (preview) {
+        Rails.ajax({
+          type: "POST",
+          url: "/stories/render_markdown",
+          data: `markdown=${encodeURIComponent(desc.value)}`,
+          dataType: "text",
+          success: (response) => {
+            preview.innerHTML = response;
+          },
+        });
+      }
     }
   }
+
+  preview_setup("story-description", ".story_preview")
+  preview_setup("story-extra-info", ".extra_info_preview")
 });

--- a/app/assets/javascripts/stories.js
+++ b/app/assets/javascripts/stories.js
@@ -1,23 +1,17 @@
 document.addEventListener("input", (e) => {
-  function preview_setup(text_area_class, preview_class) {
-    if (e.target.classList.contains(text_area_class)) {
-      const desc = e.target;
-      const form = desc.closest("form");
-      const preview = form.querySelector(preview_class  + " .content");
-      if (preview) {
-        Rails.ajax({
-          type: "POST",
-          url: "/stories/render_markdown",
-          data: `markdown=${encodeURIComponent(desc.value)}`,
-          dataType: "text",
-          success: (response) => {
-            preview.innerHTML = response;
-          },
-        });
-      }
+  document.querySelectorAll('[data-has-preview]').forEach(element => {
+    const form = element.closest("form");
+    const preview = form.querySelector("." + element.dataset.previewTarget  + " .content")
+    if (preview) {
+      Rails.ajax({
+        type: "POST",
+        url: "/stories/render_markdown",
+        data: `markdown=${encodeURIComponent(element.value)}`,
+        dataType: "text",
+        success: (response) => {
+          preview.innerHTML = response;
+        },
+      });
     }
-  }
-
-  preview_setup("story-description", ".story_preview")
-  preview_setup("story-extra-info", ".extra_info_preview")
+  })
 });

--- a/app/assets/stylesheets/stories.scss
+++ b/app/assets/stylesheets/stories.scss
@@ -10,7 +10,7 @@
   word-break: break-all;
 }
 
-.story-description {
+.story-description, .extra-info {
   margin-bottom: 25px;
   font-size: 15px;
   p{
@@ -51,6 +51,7 @@
     "error error"
     "title preview"
     "description preview"
+    "extra extra-preview"
     "submit .";
   grid-template-columns: repeat(2, minmax(50%, 1fr));
   grid-column-gap: 10px;
@@ -69,17 +70,26 @@
     &.story_description {
       grid-area: description;
     }
+
+    &.story_extra_info {
+      grid-area: extra;
+    }
   }
 
   .story_preview {
     grid-area: preview;
-    .content {
-      overflow: auto;
-      max-height: min(50vh, 700px);
-      // prevent long links from overflowing
-      a {
-        word-break: break-all;
-      }
+  }
+
+  .extra_info_preview {
+    grid-area: extra-preview;
+  }
+
+  .extra_info_preview .content, .story_preview .content {
+    overflow: auto;
+    max-height: min(50vh, 700px);
+    // prevent long links from overflowing
+    a {
+      word-break: break-all;
     }
   }
 

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -120,7 +120,7 @@ class StoriesController < ApplicationController
   end
 
   def stories_params
-    params.require(:story).permit(:title, :description, :project_id)
+    params.require(:story).permit(:title, :description, :extra_info, :project_id)
   end
 
   def expected_csv_headers?(file)

--- a/app/views/estimates/_modal_body.html.erb
+++ b/app/views/estimates/_modal_body.html.erb
@@ -1,2 +1,3 @@
 <%= render "shared/story", story: @story %>
+
 <%= render partial: 'form', locals: {estimate: @estimate, story: @story, project: @project, remote: true} %>

--- a/app/views/shared/_story.html.erb
+++ b/app/views/shared/_story.html.erb
@@ -3,3 +3,7 @@
 <div class="story-description">
   <%= markdown(story.description) %>
 </div>
+
+<div class="extra-info">
+  <%= markdown(story.extra_info) %>
+</div>

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -11,6 +11,8 @@
     </div>
   <% end %>
 
+  <%= f.hidden_field :project_id, value: params[:project_id] %>
+
   <div class="field story_title">
     <%= f.label :title %>
     <%= f.text_field :title, placeholder: "Story Title", class: "project-story-title" %>
@@ -21,12 +23,21 @@
     <%= f.text_area :description, placeholder: "Description", class: "story-description", rows: 20 %>
   </div>
 
-  <%= f.hidden_field :project_id, value: params[:project_id] %>
-
   <div class="story_preview">
     <label>Description Preview</label>
     <div class="content"><%= markdown(@story.description) %></div>
   </div>
+
+  <div class="field story_extra_info">
+    <%= f.label :extra_info, "Extra Info (Markdown - for context only, not added to action plan)" %>
+    <%= f.text_area :extra_info, placeholder: "Extra Indo", class: "story-extra-info", rows: 20 %>
+  </div>
+
+  <div class="extra_info_preview">
+    <label>Extra Info Preview</label>
+    <div class="content"><%= markdown(@story.extra_info) %></div>
+  </div>
+
 
   <div class="btn-group">
     <%= f.submit yield(:button_text), class: "button", id: "edit" %>

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -20,7 +20,7 @@
 
   <div class="field story_description">
     <%= f.label :description, "Description (Markdown)" %>
-    <%= f.text_area :description, placeholder: "Description", class: "story-description", rows: 20 %>
+    <%= f.text_area :description, placeholder: "Description", class: "story-description", rows: 20, 'data-has-preview': true, 'data-preview-target': 'story_preview' %>
   </div>
 
   <div class="story_preview">
@@ -30,7 +30,7 @@
 
   <div class="field story_extra_info">
     <%= f.label :extra_info, "Extra Info (Markdown - for context only, not added to action plan)" %>
-    <%= f.text_area :extra_info, placeholder: "Extra Indo", class: "story-extra-info", rows: 20 %>
+    <%= f.text_area :extra_info, placeholder: "Extra Indo", class: "story-extra-info", rows: 20, 'data-has-preview': true, 'data-preview-target': 'extra_info_preview' %>
   </div>
 
   <div class="extra_info_preview">

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -2,6 +2,7 @@
   <h1 class="dashboard-title"><%= render "shared/project_title", project: @project %></h1>
 
   <%= render "shared/story", story: @story %>
+
   <div class="btn-group">
     <%= link_to 'Edit', edit_project_story_path(@project), id:"back", class: "button" %>
     <%= link_to 'Back', project_path(@project), id:"back", class: "button" %>

--- a/db/migrate/20220312201424_add_extra_info_to_stories.rb
+++ b/db/migrate/20220312201424_add_extra_info_to_stories.rb
@@ -1,0 +1,5 @@
+class AddExtraInfoToStories < ActiveRecord::Migration[6.1]
+  def change
+    add_column :stories, :extra_info, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_09_170501) do
+ActiveRecord::Schema.define(version: 2022_03_12_201424) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 2021_12_09_170501) do
     t.datetime "updated_at", null: false
     t.integer "position"
     t.integer "real_score"
+    t.string "extra_info"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/stories.rb
+++ b/spec/factories/stories.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :story do
     title { Faker::ChuckNorris.fact }
     description { Faker::Marketing.buzzwords }
+    extra_info { Faker::Marketing.buzzwords }
     real_score { 2 }
     project
   end

--- a/spec/features/action_plan_generate_spec.rb
+++ b/spec/features/action_plan_generate_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "generating an action plan", js: true do
 
   let!(:project) do
     FactoryBot.create(:project, parent: parent).tap do |project|
-      FactoryBot.create(:story, title: "Second Story", description: "Second", position: 2, project: project)
+      FactoryBot.create(:story, title: "Second Story", description: "Second", position: 2, project: project, extra_info: "Extra Information")
       FactoryBot.create(:story, title: "First Story", description: "First", position: 1, project: project)
     end
   end
@@ -32,6 +32,7 @@ RSpec.describe "generating an action plan", js: true do
     expect(page).to have_selector("input[name='action-plan-prefix']")
     expect(page).to have_selector("h3.action-plan_heading > span", visible: false)
     expect(page.all("#action-plan h3").map(&:text)).to eq(["First Story", "Second Story"])
+    # This assertion alsp ensure the extra_info key we populated doesn't appear
     expect(page.all("#action-plan p").map(&:text)).to eq(["First", "Second"])
 
     # Set prefix

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "managing stories", js: true do
     click_link "Add a Story"
     fill_in "story[title]", with: "As a user, I want to add stories"
     fill_in "story[description]", with: "This story allows users to add stories."
+    fill_in "story[extra_info]", with: "This story allows users to add extra details."
     click_button "Create"
     expect(Story.count).to eq 2
   end
@@ -105,6 +106,44 @@ RSpec.describe "managing stories", js: true do
     within(".story_preview .content") do
       expect(page).to have_selector("p", text: "This story allows users to add stories.")
       expect(page).to have_selector("pre", text: "some\ncode")
+    end
+  end
+
+  it "shows a preview of the extra information while typing" do
+    visit project_path(id: project.id)
+    click_link "Add a Story"
+    fill_in "story[title]", with: "As a user, I want to add stories"
+
+    desc = <<~DESC
+      This story allows users to add extra information.
+
+          some
+          codes
+
+    DESC
+
+    fill_in "story[extra_info]", with: desc
+
+    within(".extra_info_preview .content") do
+      expect(page).to have_selector("p", text: "This story allows users to add extra information.")
+      expect(page).to have_selector("pre", text: "some\ncodes")
+    end
+
+    click_button "Create"
+
+    expect(page).to have_text(project.title)
+
+    story = Story.last
+    within_story_row(story) do
+      click_button "More actions"
+      click_link "Edit"
+    end
+
+    expect(page).to have_text("Edit Story")
+
+    within(".extra_info_preview .content") do
+      expect(page).to have_selector("p", text: "This story allows users to add extra information.")
+      expect(page).to have_selector("pre", text: "some\ncodes")
     end
   end
 


### PR DESCRIPTION
Closes #125

**Description:**

Add an extra_info field to stories which is shown to users when planning but not in the action plan itself. This allows users to add context to issues to add context details for individuals trying to  add estimates when those details won't be important after the estimating process.


<img width="988" alt="Screen Shot 2022-03-12 at 9 22 03 PM" src="https://user-images.githubusercontent.com/607860/158042141-1ff395fa-1e39-4b45-8089-e983781cb7a1.png">
<img width="1004" alt="Screen Shot 2022-03-12 at 9 22 16 PM" src="https://user-images.githubusercontent.com/607860/158042143-b65c4edf-cbcd-4a59-8ef0-c8851bbf30c6.png">
<img width="1007" alt="Screen Shot 2022-03-12 at 9 22 27 PM" src="https://user-images.githubusercontent.com/607860/158042144-5d04a14d-0427-46e6-a918-47f91553dfbd.png">

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).
