### PR TITLE
Implement confirmation popup on bulk deletion

### DIFF
--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -26,6 +26,8 @@ document.addEventListener("turbolinks:load", function () {
       stories_ids.push($(checkbox).val());
     });
 
+    const ending = stories_ids.length == 1 ? "y" : "ies";
+
     $(event.target)
       .text("Bulk Delete")
       .attr("aria-disabled", "true")

--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -28,7 +28,7 @@ document.addEventListener("turbolinks:load", function () {
 
     const ending = stories_ids.length == 1 ? "y" : "ies";
     let user_confirmation = confirm(
-      `Are you sure you want to bulk delete ${stories_ids.length} stor${ending}?`
+      `Are you sure you want to delete ${stories_ids.length} stor${ending}?`
     );
     if (!user_confirmation) return;
 

--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -27,6 +27,10 @@ document.addEventListener("turbolinks:load", function () {
     });
 
     const ending = stories_ids.length == 1 ? "y" : "ies";
+    let user_confirmation = confirm(
+      `Are you sure you want to bulk delete ${stories_ids.length} stor${ending}?`
+    );
+    if (!user_confirmation) return;
 
     $(event.target)
       .text("Bulk Delete")

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe "managing stories", js: true do
     page.accept_confirm "Are you sure you want to delete 1 story?" do
       click_button("Bulk Delete (1 Story)")
     end
+    sleep(1)
     expect(Story.count).to eq 0
   end
 

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -67,10 +67,23 @@ RSpec.describe "managing stories", js: true do
     expect(page).to have_no_selector("#bulk_delete[aria-disabled='true']")
     expect(page).to have_no_selector("#bulk_delete[disabled]")
     expect(page).to have_button("Bulk Delete (1 Story)")
-    page.accept_alert do
+    page.accept_confirm "Are you sure you want to delete 1 story?" do
       click_button("Bulk Delete (1 Story)")
     end
     expect(Story.count).to eq 0
+  end
+
+  it "does not bulk delete stories when confirmation is dismissed" do
+    visit project_path(id: project.id)
+
+    within_story_row(story) { check(option: story.id.to_s) }
+    expect(page).to have_no_selector("#bulk_delete[aria-disabled='true']")
+    expect(page).to have_no_selector("#bulk_delete[disabled]")
+    expect(page).to have_button("Bulk Delete (1 Story)")
+    page.dismiss_confirm "Are you sure you want to delete 1 story?" do
+      click_button("Bulk Delete (1 Story)")
+    end
+    expect(Story.count).to eq 1
   end
 
   it "shows a preview of the description while typing" do

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -67,7 +67,9 @@ RSpec.describe "managing stories", js: true do
     expect(page).to have_no_selector("#bulk_delete[aria-disabled='true']")
     expect(page).to have_no_selector("#bulk_delete[disabled]")
     expect(page).to have_button("Bulk Delete (1 Story)")
-    click_button("Bulk Delete (1 Story)")
+    page.accept_alert do
+      click_button("Bulk Delete (1 Story)")
+    end
     expect(Story.count).to eq 0
   end
 


### PR DESCRIPTION
**Description:**

This pull request closes #241.
As the issue describes, the old code for bulk deletion did not ask the user for confirmation, this PR fixes the problem and implements a confirmation popup.
___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).
