### PR TITLE
Fix stories_manage_spec

### DIFF
--- a/app/assets/javascripts/stories.js
+++ b/app/assets/javascripts/stories.js
@@ -1,17 +1,21 @@
-document.addEventListener("input", (e) => {
-  document.querySelectorAll('[data-has-preview]').forEach(element => {
-    const form = element.closest("form");
-    const preview = form.querySelector("." + element.dataset.previewTarget  + " .content")
-    if (preview) {
-      Rails.ajax({
-        type: "POST",
-        url: "/stories/render_markdown",
-        data: `markdown=${encodeURIComponent(element.value)}`,
-        dataType: "text",
-        success: (response) => {
-          preview.innerHTML = response;
-        },
-      });
-    }
-  })
+document.addEventListener("turbolinks:load", function () {
+  document.addEventListener("input", (e) => {
+    document.querySelectorAll("[data-has-preview]").forEach((element) => {
+      const form = element.closest("form");
+      const preview = form.querySelector(
+        "." + element.dataset.previewTarget + " .content"
+      );
+      if (preview) {
+        Rails.ajax({
+          type: "POST",
+          url: "/stories/render_markdown",
+          data: `markdown=${encodeURIComponent(element.value)}`,
+          dataType: "text",
+          success: (response) => {
+            preview.innerHTML = response;
+          },
+        });
+      }
+    });
+  });
 });

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "managing stories", js: true do
     expect(Story.count).to eq 0
   end
 
-  it "shows a preview of the description while typing" do
+  it "shows a preview of the description while typing", js: true do
     visit project_path(id: project.id)
     click_link "Add a Story"
     fill_in "story[title]", with: "As a user, I want to add stories"


### PR DESCRIPTION
**Description:**

Capybara failed intermittently when running spec/features/stories_manage_spec.rb. It also failed all the time when we add a sleep(1) on line 89.

Seems like the JS on this page refreshes the page after we already typed our input. This is most likely only an issue we will find with automated tests. To fix this we wait for the `turbolinks:load` event before we attach the input listener.

This seems to work for automated tests, without any regression in real world use.

This issue was found when we tried to troubleshoot another PR that kept on failing during the CI run.
https://github.com/fastruby/points/pull/244

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).
