### PR TITLE
Revert js changes instead add sleeps

### DIFF
--- a/app/assets/javascripts/stories.js
+++ b/app/assets/javascripts/stories.js
@@ -1,19 +1,25 @@
 document.addEventListener("input", (e) => {
-  document.querySelectorAll("[data-has-preview]").forEach((element) => {
-    const form = element.closest("form");
-    const preview = form.querySelector(
-      "." + element.dataset.previewTarget + " .content"
-    );
-    if (preview) {
-      Rails.ajax({
-        type: "POST",
-        url: "/stories/render_markdown",
-        data: `markdown=${encodeURIComponent(element.value)}`,
-        dataType: "text",
-        success: (response) => {
-          preview.innerHTML = response;
-        },
-      });
-    }
-  });
+  const updateMarkdown = () => {
+    document.querySelectorAll("[data-has-preview]").forEach((element) => {
+      const form = element.closest("form");
+      const preview = form.querySelector(
+        "." + element.dataset.previewTarget + " .content"
+      );
+      if (preview) {
+        Rails.ajax({
+          type: "POST",
+          url: "/stories/render_markdown",
+          data: `markdown=${encodeURIComponent(element.value)}`,
+          dataType: "text",
+          success: (response) => {
+            preview.innerHTML = response;
+          },
+        });
+      }
+    });
+  };
+
+  var debounceTimer;
+  window.clearTimeout(debounceTimer);
+  debounceTimer = window.setTimeout(updateMarkdown, 300);
 });

--- a/app/assets/javascripts/stories.js
+++ b/app/assets/javascripts/stories.js
@@ -1,21 +1,19 @@
-document.addEventListener("turbolinks:load", function () {
-  document.addEventListener("input", (e) => {
-    document.querySelectorAll("[data-has-preview]").forEach((element) => {
-      const form = element.closest("form");
-      const preview = form.querySelector(
-        "." + element.dataset.previewTarget + " .content"
-      );
-      if (preview) {
-        Rails.ajax({
-          type: "POST",
-          url: "/stories/render_markdown",
-          data: `markdown=${encodeURIComponent(element.value)}`,
-          dataType: "text",
-          success: (response) => {
-            preview.innerHTML = response;
-          },
-        });
-      }
-    });
+document.addEventListener("input", (e) => {
+  document.querySelectorAll("[data-has-preview]").forEach((element) => {
+    const form = element.closest("form");
+    const preview = form.querySelector(
+      "." + element.dataset.previewTarget + " .content"
+    );
+    if (preview) {
+      Rails.ajax({
+        type: "POST",
+        url: "/stories/render_markdown",
+        data: `markdown=${encodeURIComponent(element.value)}`,
+        dataType: "text",
+        success: (response) => {
+          preview.innerHTML = response;
+        },
+      });
+    }
   });
 });

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe "managing stories", js: true do
 
     DESC
 
+    sleep(1)
     fill_in "story[description]", with: desc
 
     within(".story_preview .content") do
@@ -151,6 +152,7 @@ RSpec.describe "managing stories", js: true do
 
     DESC
 
+    sleep(1)
     fill_in "story[extra_info]", with: desc
 
     within(".extra_info_preview .content") do

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "managing stories", js: true do
     end
     expect(Story.count).to eq 1
   end
-  
+
   it "shows a preview of the description while typing", js: true do
     visit project_path(id: project.id)
     click_link "Add a Story"
@@ -116,6 +116,7 @@ RSpec.describe "managing stories", js: true do
 
     expect(page).to have_text("Description Preview")
     fill_in "story[description]", with: desc
+    expect(find("#story_description").value).to have_text("This story allows users to add stories.\n\n    some\n    code\n\n")
 
     within(".story_preview .content") do
       expect(page).to have_text("This story allows users to add stories.")

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -83,7 +83,8 @@ RSpec.describe "managing stories", js: true do
     page.accept_confirm "Are you sure you want to delete 1 story?" do
       click_button("Bulk Delete (1 Story)")
     end
-    sleep(1)
+    # Make sure tbody empty
+    expect(find("tbody")).to have_no_css("*")
     expect(Story.count).to eq 0
   end
 
@@ -113,7 +114,7 @@ RSpec.describe "managing stories", js: true do
 
     DESC
 
-    sleep(1)
+    expect(page).to have_text("Description Preview")
     fill_in "story[description]", with: desc
 
     within(".story_preview .content") do
@@ -152,7 +153,7 @@ RSpec.describe "managing stories", js: true do
 
     DESC
 
-    sleep(1)
+    expect(page).to have_text("Extra Info Preview")
     fill_in "story[extra_info]", with: desc
 
     within(".extra_info_preview .content") do
@@ -282,7 +283,10 @@ RSpec.describe "managing stories", js: true do
 
     last.drag_to(first, delay: 0, html5: false)
 
-    sleep(1)
+    within("#stories") do
+      expect(find("tr:nth-child(1)")).to have_text story3.title
+      expect(find("tr:nth-child(2)")).to have_text story.title
+    end
 
     expect(page).not_to have_selector(".project-table.sorting")
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Project, type: :model do
       sub_project1 = FactoryBot.create(:project, parent: parent)
 
       expect(sub_project1).not_to be_archived
-    end    
+    end
   end
 
   describe "#toggle_archived!" do


### PR DESCRIPTION
**Description:**

I though the problem was related to waiting for the page to load before
adding the appropriate listeners. Instead the problem was giving the
page enough time before filling out the forms during tests.

Please include a summary of the change and which issue is fixed or which feature is introduced. If changes to the behavior are made, clearly describe what changes.
If changes to the UI are made, please include screenshots of the before and after.

Jira: https://ombulabs.atlassian.net/browse/DT-268
___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).
