### PR TITLE
Enable/disable RMP with a cookie, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ and then:
 User.find_by(email: "user@example.com").update_attribute(:admin, true)
 ```
 
+## Rack Mini Profiler
+
+To enable the Rack Mini Profiler widget, add the `?enable_rack_mini_profiler` query string to any url. The widget will stay on for all requests until disabled.
+
+To disable the Rack Mini Profiler widget, add the `?disable_rack_mini_profiler` query string to any url.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at [https://github.com/fastruby/points](https://github.com/fastruby/points). This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-  before_action :enable_rack_mini_profiler
+  before_action :rack_mini_profiler
 
   def hello
     render html: "hello, world!"
@@ -13,7 +13,18 @@ class ApplicationController < ActionController::Base
   private
 
   # we can enable this for everybody, it's hidden by default
-  def enable_rack_mini_profiler
-    Rack::MiniProfiler.authorize_request
+  def rack_mini_profiler
+    show =
+      if params.key?(:enable_rack_mini_profiler)
+        cookies[:rack_mini_profiler] = "show"
+        true
+      elsif params.key?(:disable_rack_mini_profiler)
+        cookies.delete(:rack_mini_profiler)
+        false
+      end
+
+    if show || cookies[:rack_mini_profiler]
+      Rack::MiniProfiler.authorize_request
+    end
   end
 end

--- a/config/initializers/rack_mini_profiler.rb
+++ b/config/initializers/rack_mini_profiler.rb
@@ -1,2 +1,1 @@
-Rack::MiniProfiler.config.start_hidden = true
-Rack::MiniProfiler.config.toggle_shortcut = "Alt+Ctrl+P"
+Rack::MiniProfiler.config.authorization_mode = :allow_authorized


### PR DESCRIPTION
**Description:**

This PR changes the rack mini profiler setup to allow the user to enable/disable passing an `?enable_rack_mini_profiler` or `?disable_rack_mini_profiler` query estring parameter.

The query string param also applies for the development environment.

With this we don't need the Ctrl+Alt+P shortcut to toggle it on/off after it rendered and we can disable it completely to avoid extra requests and extra code in responses unless manually enabled.

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).
