### PR TITLE
DT-329 add locked label for locked projects

### DIFF
--- a/app/assets/stylesheets/2-quarks/_typography.scss
+++ b/app/assets/stylesheets/2-quarks/_typography.scss
@@ -42,7 +42,7 @@ h1{
 h2{
   font-size: 41px;
   font-weight: 300;
-  line-height: 1.2em;
+  line-height: 1.5em;
 }
 h3{
   font-size: 14px;

--- a/app/assets/stylesheets/3-atoms/_badges.scss
+++ b/app/assets/stylesheets/3-atoms/_badges.scss
@@ -1,27 +1,22 @@
 .status-badge {
   display: inline-block;
-  padding: 10px 20px;
-  font-weight: 700;
-  line-height: 0.5;
+  padding: 7px 15px;
+  font-weight: 600;
+  line-height: 1;
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
   border-radius: 20px;
+  font-size: 11px;
 
   &.archived {
     background-color: rgba(29,78,216,0.2);
     border-color: #1d4ed8;
-    font-weight: 600;
-    padding: 10px 20px;
-    font-size: 20px;
   }
 
   &.locked {
     background-color: rgba(255, 0, 0, 32%);
     border-color: #d77e72;
-    font-weight: 600;
-    padding: 10px 20px;
-    font-size: 20px;
   }
 
   &.list {

--- a/app/assets/stylesheets/3-atoms/_badges.scss
+++ b/app/assets/stylesheets/3-atoms/_badges.scss
@@ -19,9 +19,4 @@
     border-color: #d77e72;
   }
 
-  &.list {
-    font-weight: 500;
-    padding: 5px 10px;
-    font-size: 10px;
-  }
 }

--- a/app/assets/stylesheets/3-atoms/_badges.scss
+++ b/app/assets/stylesheets/3-atoms/_badges.scss
@@ -2,7 +2,7 @@
   display: inline-block;
   padding: 10px 20px;
   font-weight: 700;
-  line-height: 1;
+  line-height: 0.5;
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
@@ -11,5 +11,22 @@
   &.archived {
     background-color: rgba(29,78,216,0.2);
     border-color: #1d4ed8;
+    font-weight: 600;
+    padding: 10px 20px;
+    font-size: 20px;
+  }
+
+  &.locked {
+    background-color: rgba(255, 0, 0, 32%);
+    border-color: #d77e72;
+    font-weight: 600;
+    padding: 10px 20px;
+    font-size: 20px;
+  }
+
+  &.list {
+    font-weight: 500;
+    padding: 5px 10px;
+    font-size: 10px;
   }
 }

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -9,8 +9,8 @@
             <%= link_to project_path(project.id) do %>
               <div>
                 <h2><%= project.title %></h2>
-                <span class="status-badge locked list <%= "hide" if project.locked_at.nil? %>">Locked</span>
-                <span class="status-badge <%= project.status %> list "><%= project.status %></span>
+                <span class="status-badge locked <%= "hide" if project.locked_at.nil? %>">Locked</span>
+                <span class="status-badge <%= project.status %>"><%= project.status %></span>
               </div>
             <% end %>
             <div class="sortable-projects" data-url="<%= sort_project_path(project.id) %>">

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -2,7 +2,7 @@
   <h1 class="home-title">Projects</h1>
 
   <% if @projects.any? %>
-    <div class="row">
+    <div class="row" id="projects">
       <% @projects.each do | project | %>
         <div class="col-sm-6 col-lg-4">
           <div class="project-card" id="project_<%= project.id %>">

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -9,7 +9,8 @@
             <%= link_to project_path(project.id) do %>
               <div>
                 <h2><%= project.title %></h2>
-                <span class="status-badge <%= project.status %>"><%= project.status %></span>
+                <span class="status-badge locked list <%= "hide" if project.locked_at.nil? %>">Locked</span>
+                <span class="status-badge <%= project.status %> list "><%= project.status %></span>
               </div>
             <% end %>
             <div class="sortable-projects" data-url="<%= sort_project_path(project.id) %>">

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -14,7 +14,10 @@
       <% if @projects.present? %>
         <% @projects.each do | project | %>
         <tr class="project-table__row project-table__row--project-reports project-table__row--story">
-          <td class="project-table__cell"><span class="status-badge locked list <%= "hide" if project.locked_at.nil? %>">Locked</span> <%= project.title%></td>
+          <td class="project-table__cell">
+            <span class="status-badge locked list <%= "hide" if project.locked_at.nil? %>">Locked</span>
+            <%= project.title%>
+          </td>
           <td class="project-table__cell"><%= link_to "View Report", project_report_path(project.id), class: "button green" %></td>
         </tr>
         <% end %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -14,7 +14,7 @@
       <% if @projects.present? %>
         <% @projects.each do | project | %>
         <tr class="project-table__row project-table__row--project-reports project-table__row--story">
-          <td class="project-table__cell"><%= project.title%></td>
+          <td class="project-table__cell"><span class="status-badge locked list <%= "hide" if project.locked_at.nil? %>">Locked</span> <%= project.title%></td>
           <td class="project-table__cell"><%= link_to "View Report", project_report_path(project.id), class: "button green" %></td>
         </tr>
         <% end %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -15,7 +15,7 @@
         <% @projects.each do | project | %>
         <tr class="project-table__row project-table__row--project-reports project-table__row--story">
           <td class="project-table__cell">
-            <span class="status-badge locked list <%= "hide" if project.locked_at.nil? %>">Locked</span>
+            <span class="status-badge locked <%= "hide" if project.locked_at.nil? %>">Locked</span>
             <%= project.title%>
           </td>
           <td class="project-table__cell"><%= link_to "View Report", project_report_path(project.id), class: "button green" %></td>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,5 +1,7 @@
 <div class="container">
   <h1 class="dashboard-title-report"><%= @project.title %> Report</h1>
+  <br>
+  <span class="status-badge locked <%= "hide" if @project.locked_at.nil? %>">Locked</span>
 
   <table class="project-table">
     <thead class="fixed-header">

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,6 +1,8 @@
 <div class="container">
-  <h1 class="dashboard-title-report"><%= @project.title %> Report <br> <span class="status-badge locked <%= "hide" if @project.locked_at.nil? %>">Locked</span> </h1>
-
+  <div class="heading">
+    <h1 class="dashboard-title-report"><%= @project.title %> Report</h1>
+    <span class="status-badge locked <%= "hide" if @project.locked_at.nil? %>">Locked</span>
+  </div>
   <table class="project-table">
     <thead class="fixed-header">
       <tr class="project-table__row project-table__row--reports project-table__row--header">

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,7 +1,5 @@
 <div class="container">
-  <h1 class="dashboard-title-report"><%= @project.title %> Report</h1>
-  <br>
-  <span class="status-badge locked <%= "hide" if @project.locked_at.nil? %>">Locked</span>
+  <h1 class="dashboard-title-report"><%= @project.title %> Report <br> <span class="status-badge locked <%= "hide" if @project.locked_at.nil? %>">Locked</span> </h1>
 
   <table class="project-table">
     <thead class="fixed-header">

--- a/app/views/shared/_project_title.html.erb
+++ b/app/views/shared/_project_title.html.erb
@@ -18,5 +18,6 @@
 <% else %>
   <%= project.title %>
 <% end %>
-
-<span class="status-badge <%= project.status %> <%= "hide" if project.status == nil %>"><%= project.status %></span>
+<br>
+<span class="status-badge locked <%= "hide" if project.locked_at.nil? %>">Locked</span>
+<span class="status-badge <%= project.status %> <%= "hide" if project.status.nil? %>"><%= project.status %></span>

--- a/app/views/shared/_project_title.html.erb
+++ b/app/views/shared/_project_title.html.erb
@@ -19,5 +19,7 @@
   <%= project.title %>
 <% end %>
 <br>
-<span class="status-badge locked <%= "hide" if project.locked_at.nil? %>">Locked</span>
-<span class="status-badge <%= project.status %> <%= "hide" if project.status.nil? %>"><%= project.status %></span>
+<div>
+  <span class="status-badge locked <%= "hide" if project.locked_at.nil? %>">Locked</span>
+  <span class="status-badge <%= project.status %> <%= "hide" if project.status.nil? %>"><%= project.status %></span>
+</div>

--- a/app/views/shared/_project_title.html.erb
+++ b/app/views/shared/_project_title.html.erb
@@ -18,7 +18,7 @@
 <% else %>
   <%= project.title %>
 <% end %>
-<br>
+
 <div>
   <span class="status-badge locked <%= "hide" if project.locked_at.nil? %>">Locked</span>
   <span class="status-badge <%= project.status %> <%= "hide" if project.status.nil? %>"><%= project.status %></span>

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :project do
     title { Faker::Company.name }
+    trait :locked do
+      locked_at { Time.current }
+    end
   end
 end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -4,5 +4,8 @@ FactoryBot.define do
     trait :locked do
       locked_at { Time.current }
     end
+    trait :archived do
+      status { "archived" }
+    end
   end
 end

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe "managing projects", js: true do
     it "allow me to clone the project" do
       expect(page).to have_selector(:link_or_button, "Clone Project", disabled: false)
     end
+
+    it "has an archived label" do
+      expect(page).to have_selector("span.archived")
+    end
   end
 
   context "when the project is unarchived" do
@@ -331,29 +335,60 @@ RSpec.describe "managing projects", js: true do
     end
   end
 
-  describe "as an admin user" do
-    let(:user) { FactoryBot.create(:user, admin: true) }
-    let(:story) { FactoryBot.create(:story) }
+  describe "when locking a project" do
 
-    context "when a project is unlocked" do
-      it "locks a project" do
-        visit project_path(id: project.id)
+    context "when a user is an admin" do
+      let(:user) { FactoryBot.create(:user, admin: true) }
 
-        expect(page).to have_selector(:link_or_button, "Lock Project")
-        click_button "Lock Project"
+      context "if a project is unlocked" do
+        it "locks a project" do
+          visit project_path(id: project.id)
 
-        ["Delete Project", "Lock Project", "Add Sub-Project", "Add a Story"].each do |btn|
-          expect(page).not_to have_selector(:link_or_button, btn)
+          expect(page).to have_selector(:link_or_button, "Lock Project")
+          click_button "Lock Project"
+
+          hide_locked_project_buttons
+        end
+      end
+    end
+
+    context "when a user is not an admin" do
+      let(:user) { FactoryBot.create(:user) }
+
+      context "if a project is unlocked" do
+        let(:project) { FactoryBot.create(:project) }
+
+        it "does not render locked button" do
+          visit project_path(id: project.id)
+
+          expect(page).to have_no_selector(:link_or_button, "Lock Project")
+        end
+      end
+
+      context "if a project is locked" do
+        let(:locked_project) { FactoryBot.create(:project, :locked) }
+
+        it "does not allow project to be edited" do
+          visit project_path(id: locked_project.id)
+
+          hide_locked_project_buttons
         end
       end
     end
 
     context "when a project is locked" do
-      before do
-        story.project.update(locked_at: Time.current)
+      let(:locked_project) { FactoryBot.create(:project, :locked, title: "Some Project") }
+      let(:story) { FactoryBot.create(:story) }
+
+      it "has a locked label" do
+        visit project_path(locked_project)
+        within ".dashboard-title" do
+          expect(page).to have_text("Locked")
+        end
       end
 
       it "hides project stories edit and delete buttons" do
+        story.project.update(locked_at: Time.current)
         visit project_story_path(story.project_id, story.id)
 
         ["Edit", "Delete"].each do |btn|
@@ -362,13 +397,21 @@ RSpec.describe "managing projects", js: true do
       end
 
       it "doesn't enable the bulk delete button" do
+        story.project.update(locked_at: Time.current)
         visit project_path(story.project)
 
         within "tr#story_#{story.id}" do
           find("input[type='checkbox'][value='#{story.id}']").set(true)
         end
+
         expect(page).to have_button("Bulk Delete", disabled: true)
       end
+    end
+  end
+
+  def hide_locked_project_buttons
+    ["Delete Project", "Lock Project", "Add Sub-Project", "Add a Story"].each do |btn|
+      expect(page).not_to have_selector(:link_or_button, btn)
     end
   end
 end

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -347,7 +347,7 @@ RSpec.describe "managing projects", js: true do
           expect(page).to have_selector(:link_or_button, "Lock Project")
           click_button "Lock Project"
 
-          hide_locked_project_buttons
+          expect_buttons_to_be_hidden
         end
       end
     end
@@ -371,19 +371,37 @@ RSpec.describe "managing projects", js: true do
         it "does not allow project to be edited" do
           visit project_path(id: locked_project.id)
 
-          hide_locked_project_buttons
+          expect_buttons_to_be_hidden
         end
       end
     end
 
     context "when a project is locked" do
-      let(:locked_project) { FactoryBot.create(:project, :locked, title: "Some Project") }
+      let!(:locked_project) { FactoryBot.create(:project, :locked, title: "Some Project") }
       let(:story) { FactoryBot.create(:story) }
 
-      it "has a locked label" do
+      it "shows a locked label for projects" do
+        visit projects_path
+        within "#projects" do
+          expect(page).to have_text("Locked", count: 1)
+        end
+
         visit project_path(locked_project)
         within ".dashboard-title" do
           expect(page).to have_text("Locked")
+        end
+      end
+
+      it "shows a locked label for archived projects" do
+        archived_project = FactoryBot.create(:project, :locked, status: "archived")
+        visit projects_path(archived: true)
+        within "#projects" do
+          expect(page).to have_text("Locked", count: 1)
+        end
+
+        visit project_path(archived_project)
+        within ".dashboard-title" do
+          expect(page).to have_text("Locked", count: 1)
         end
       end
 
@@ -409,7 +427,7 @@ RSpec.describe "managing projects", js: true do
     end
   end
 
-  def hide_locked_project_buttons
+  def expect_buttons_to_be_hidden
     ["Delete Project", "Lock Project", "Add Sub-Project", "Add a Story"].each do |btn|
       expect(page).not_to have_selector(:link_or_button, btn)
     end

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "managing projects", js: true do
     end
 
     it "has an archived label" do
-      expect(page).to have_selector("span.archived")
+      expect(page).to have_text("archived")
     end
   end
 
@@ -393,7 +393,7 @@ RSpec.describe "managing projects", js: true do
       end
 
       it "shows a locked label for archived projects" do
-        archived_project = FactoryBot.create(:project, :locked, status: "archived")
+        archived_project = FactoryBot.create(:project, :locked, :archived)
         visit projects_path(archived: true)
         within "#projects" do
           expect(page).to have_text("Locked", count: 1)

--- a/spec/features/reports_manage_spec.rb
+++ b/spec/features/reports_manage_spec.rb
@@ -127,12 +127,18 @@ RSpec.describe "managing reports", js: true do
   end
 
   context "when a project is locked" do
-    it "has a locked label" do
-      FactoryBot.create(:project, :locked)
+
+    it "shows a locked label for projects on reports page" do
+      locked_project = FactoryBot.create(:project, :locked)
       visit reports_index_path
         within "#stories" do
           expect(page).to have_text("Locked", count: 1)
         end
+
+      visit project_report_path(locked_project)
+      within ".dashboard-title-report" do
+        expect(page).to have_text("Locked")
+      end
     end
   end
 end

--- a/spec/features/reports_manage_spec.rb
+++ b/spec/features/reports_manage_spec.rb
@@ -127,7 +127,6 @@ RSpec.describe "managing reports", js: true do
   end
 
   context "when a project is locked" do
-
     it "shows a locked label for projects on reports page" do
       locked_project = FactoryBot.create(:project, :locked)
       visit reports_index_path
@@ -136,7 +135,7 @@ RSpec.describe "managing reports", js: true do
         end
 
       visit project_report_path(locked_project)
-      within ".dashboard-title-report" do
+      within ".status-badge.locked" do
         expect(page).to have_text("Locked")
       end
     end

--- a/spec/features/reports_manage_spec.rb
+++ b/spec/features/reports_manage_spec.rb
@@ -125,4 +125,14 @@ RSpec.describe "managing reports", js: true do
       end
     end
   end
+
+  context "when a project is locked" do
+    it "has a locked label" do
+      FactoryBot.create(:project, :locked)
+      visit reports_index_path
+        within "#stories" do
+          expect(page).to have_text("Locked", count: 1)
+        end
+    end
+  end
 end


### PR DESCRIPTION
https://ombulabs.atlassian.net/browse/DT-329

Add locked label to index and show pages to make it clear projects are locked

To review the changes made navigate to the following pages:

- "/projects" should render a list of projects with a locked badge for locked projects. 
- "/projects/:id" should render a project show page with a locked badge if project is locked.
- "/reports/index" should render a list of projects. Locked projects will have a locked project badge before project title
- "/projects/:id/reports will render a project report view with a locked badge under the project title
- Click on "See Archived Projects" on projects index page lists archived projects with a locked badge if locked. 

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).
