### PR TITLE
DT-328 unlock a project

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -37,7 +37,11 @@ class ProjectsController < ApplicationController
   # PATCH /projects/1/toggle_locked.js
   def toggle_locked
     @project = Project.find(params[:id])
-    @project.update(locked_at: Time.current)
+    if @project.locked_at.nil?
+      @project.update(locked_at: Time.current)
+    else
+      @project.update(locked_at: nil)
+    end
   end
 
   def new_clone

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,6 +1,6 @@
 class ProjectsController < ApplicationController
   before_action :authenticate_user!
-  before_action :find_project, only: [:show, :edit, :update, :sort, :sort_stories, :destroy, :new_sub_project]
+  before_action :find_project, only: [:show, :edit, :update, :sort, :sort_stories, :destroy, :new_sub_project, :toggle_archive,:toggle_locked]
   before_action :ensure_unarchived!, only: [:edit, :new_sub_project, :update]
 
   def index
@@ -30,13 +30,11 @@ class ProjectsController < ApplicationController
   end
 
   def toggle_archive
-    @project = Project.find(params[:id])
     @project.toggle_archived!
   end
 
   # PATCH /projects/1/toggle_locked.js
   def toggle_locked
-    @project = Project.find(params[:id])
     if @project.locked_at.nil?
       @project.update(locked_at: Time.current)
     else

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,6 +1,6 @@
 class ProjectsController < ApplicationController
   before_action :authenticate_user!
-  before_action :find_project, only: [:show, :edit, :update, :sort, :sort_stories, :destroy, :new_sub_project, :toggle_archive,:toggle_locked]
+  before_action :find_project, only: [:show, :edit, :update, :sort, :sort_stories, :destroy, :new_sub_project, :toggle_archive, :toggle_locked]
   before_action :ensure_unarchived!, only: [:edit, :new_sub_project, :update]
 
   def index

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -101,8 +101,9 @@
   <%= render partial: "projects/import_export" if is_unlocked?(@project) %>
 
   <div class="btn-group actions">
-    <% if is_unlocked?(@project) && current_user.admin? %>
-      <%= button_to 'Lock Project', toggle_locked_project_path(@project.id), method: :patch, class: "button magenta ", id: "lock-btn", remote: true %>
+
+    <% if current_user.admin? %>
+      <%= button_to is_unlocked?(@project) ? 'Lock Project' : 'Unlock Project', toggle_locked_project_path(@project.id), method: :patch, class: "button magenta ", id: "lock-btn", remote: true %>
     <% end %>
 
     <% if is_unlocked?(@project) %>

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -460,7 +460,7 @@ RSpec.describe "managing projects", js: true do
 
   def expect_buttons_to_be_hidden
     ["Delete Project", "Lock Project", "Add Sub-Project", "Add a Story"].each do |btn|
-        expect(page).not_to have_selector(:link_or_button, btn)
+      expect(page).not_to have_selector(:link_or_button, btn)
     end
   end
 end

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -336,7 +336,6 @@ RSpec.describe "managing projects", js: true do
   end
 
   describe "when locking a project" do
-
     context "when a user is an admin" do
       let(:user) { FactoryBot.create(:user, admin: true) }
 
@@ -372,6 +371,12 @@ RSpec.describe "managing projects", js: true do
           visit project_path(id: locked_project.id)
 
           expect_buttons_to_be_hidden
+        end
+
+        it "does not render unlocked button" do
+          visit project_path(id: project.id)
+
+          expect(page).to have_no_selector(:link_or_button, "Unlock Project")
         end
       end
     end
@@ -427,9 +432,39 @@ RSpec.describe "managing projects", js: true do
     end
   end
 
+  describe "when unlocking a project" do
+    context "when a user is an admin" do
+      let(:user) { FactoryBot.create(:user, admin: true) }
+
+      context "if a project is locked" do
+        let(:locked_project) { FactoryBot.create(:project, :locked) }
+
+        it "shows an unlocked button" do
+          visit project_path(locked_project)
+          within "div.btn-group.actions" do
+            expect(page).to have_text("Unlock Project")
+          end
+        end
+
+        it "unlocks a project" do
+          visit project_path(locked_project)
+
+          click_button "Unlock Project"
+
+          within "div.btn-group.actions" do
+            expect(page).to have_text("Lock Project")
+            expect(page).not_to have_text("Unlock Project")
+          end
+        end
+      end
+    end
+  end
+
   def expect_buttons_to_be_hidden
     ["Delete Project", "Lock Project", "Add Sub-Project", "Add a Story"].each do |btn|
-      expect(page).not_to have_selector(:link_or_button, btn)
+      within "div.btn-group.actions" do
+        expect(page).not_to have_text(btn)
+      end
     end
   end
 end

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -460,9 +460,7 @@ RSpec.describe "managing projects", js: true do
 
   def expect_buttons_to_be_hidden
     ["Delete Project", "Lock Project", "Add Sub-Project", "Add a Story"].each do |btn|
-      within "div.container" do
-        expect(page).not_to have_text(btn)
-      end
+        expect(page).not_to have_selector(:link_or_button, btn)
     end
   end
 end

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -446,11 +446,9 @@ RSpec.describe "managing projects", js: true do
           end
         end
 
-        it "unlocks a project" do
+        it "unlocks a project when 'Unlock Project' is clicked" do
           visit project_path(locked_project)
-
           click_button "Unlock Project"
-
           within "div.btn-group.actions" do
             expect(page).to have_text("Lock Project")
             expect(page).not_to have_text("Unlock Project")

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -460,7 +460,7 @@ RSpec.describe "managing projects", js: true do
 
   def expect_buttons_to_be_hidden
     ["Delete Project", "Lock Project", "Add Sub-Project", "Add a Story"].each do |btn|
-      within "div.btn-group.actions" do
+      within "div.container" do
         expect(page).not_to have_text(btn)
       end
     end

--- a/spec/features/reports_manage_spec.rb
+++ b/spec/features/reports_manage_spec.rb
@@ -123,9 +123,9 @@ RSpec.describe "managing reports", js: true do
     it "shows a locked label for projects on reports page" do
       locked_project = FactoryBot.create(:project, :locked)
       visit reports_index_path
-        within "#stories" do
-          expect(page).to have_text("Locked", count: 1)
-        end
+      within "#stories" do
+        expect(page).to have_text("Locked", count: 1)
+      end
 
       visit project_report_path(locked_project)
       within ".status-badge.locked" do


### PR DESCRIPTION
Added 'Unlock Project' button to project show page to support https://ombulabs.atlassian.net/browse/DT-328
Includes toggle behavior in ProjectsController in toggle_locked which will update a projects locked_at attribute on click
Added feature tests to support unlock permissions only restricted to the admin user.

These changes will complete the admin user lock feature for Points by allowing only an admin to lock or unlock a project. 

# Testing notes
- Log in with an admin user (make your user an admin using the console rails c to `user.update(admin: true)`
- View an project (or create one if you don't have any existing projects locally)
- Click on the lock button to lock the project
- Confirm that the `lock button` is replaced with `unlock button`
- Click 'Unlock Project' to toggle the project from locked to unlocked. 
- Confirm that the project is unlocked. (The locked label should disappear and edit buttons should show again)

![Screen Shot 2022-07-29 at 11 50 10 AM](https://user-images.githubusercontent.com/30131907/181796940-0ce7574e-8c12-4779-ae4f-5d1df153bfcc.png)

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).
