### PR TITLE
DT-382 Add heroku review apps to Points

### DIFF
--- a/.github/workflows/review-app-close.yml
+++ b/.github/workflows/review-app-close.yml
@@ -1,0 +1,16 @@
+name: Destroy Review App on Close
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  destroy-review-app:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: fastruby/manage-heroku-review-app@v1
+        with:
+          action: destroy
+        env:
+          HEROKU_API_TOKEN: ${{ secrets.HEROKU_API_TOKEN }}
+          HEROKU_PIPELINE_ID: ${{ secrets.HEROKU_PIPELINE_ID }}

--- a/.github/workflows/review-app-label.yml
+++ b/.github/workflows/review-app-label.yml
@@ -1,0 +1,43 @@
+name: Heroku Review App on label
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  create-review-app:
+    if: ${{ github.event.label.name == 'create-review-app' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: fastruby/create-heroku-review-app@main
+        with:
+          action: create
+        env:
+          HEROKU_API_TOKEN: ${{ secrets.HEROKU_API_TOKEN }}
+          HEROKU_PIPELINE_ID: ${{ secrets.HEROKU_PIPELINE_ID }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: fastruby/pr-unlabeler@v1
+        with:
+          label-to-remove: "create-review-app"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  destroy-review-app:
+    if: ${{ github.event.label.name == 'destroy-review-app' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: fastruby/create-heroku-review-app@main
+        with:
+          action: destroy
+        env:
+          HEROKU_API_TOKEN: ${{ secrets.HEROKU_API_TOKEN }}
+          HEROKU_PIPELINE_ID: ${{ secrets.HEROKU_PIPELINE_ID }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: fastruby/pr-unlabeler@v1
+        with:
+          label-to-remove: "destroy-review-app"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -336,7 +336,6 @@ RSpec.describe "managing projects", js: true do
   end
 
   describe "when locking a project" do
-
     context "when a user is an admin" do
       let(:user) { FactoryBot.create(:user, admin: true) }
 

--- a/spec/features/reports_manage_spec.rb
+++ b/spec/features/reports_manage_spec.rb
@@ -123,9 +123,9 @@ RSpec.describe "managing reports", js: true do
     it "shows a locked label for projects on reports page" do
       locked_project = FactoryBot.create(:project, :locked)
       visit reports_index_path
-        within "#stories" do
-          expect(page).to have_text("Locked", count: 1)
-        end
+      within "#stories" do
+        expect(page).to have_text("Locked", count: 1)
+      end
 
       visit project_report_path(locked_project)
       within ".status-badge.locked" do


### PR DESCRIPTION
### Jira Ticket 
https://ombulabs.atlassian.net/browse/DT-382

### Motivation and Context
- Adding review apps to Points for maintainable and easy QA process. 
- Added yml files to .github/workflows so then when create-review-app label is added or removed it will deploy and disable review app
- Files added: 
  - review-app-close.yml 
  - review-app-label.yml 

### QA and Testing Instructions
- For testing, add 'create-review-app' label to open PR that will enable a review app through Heroku 
- This will provide a review app URL on the Github repo to view application on a stage-like setting before deploying to production
- Disable review apps by adding the 'destroy-review-app' label 
- More information on managing review-app can be found here https://ombulabs.slite.com/app/docs/vnE0S2bjGlP-5W

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).
