### PR TITLE
Redirect to parent show after sub project creation

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -62,7 +62,7 @@ class ProjectsController < ApplicationController
     @project = Project.new(projects_params)
     if @project.save
       flash[:success] = "Project created!"
-      redirect_to "/projects"
+      redirect_to project_path(parent_id)
     else
       flash.now[:error] = @project.errors.full_messages
       render :new
@@ -116,5 +116,13 @@ class ProjectsController < ApplicationController
 
   def clone_params
     params.require(:project).permit(:title, :parent_id)
+  end
+
+  def parent_id
+    if @project.parent_id.nil?
+      @project.id
+    else
+      @project.parent_id
+    end
   end
 end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe ProjectsController, type: :controller do
   describe "#create" do
     context "with valid attributes" do
       let(:valid_params) { FactoryBot.attributes_for(:project) }
+      let(:valid_sub_proj_params) { FactoryBot.attributes_for(:project, parent_id: project.id) }
 
       it "creates a new project" do
         expect {
@@ -74,7 +75,13 @@ RSpec.describe ProjectsController, type: :controller do
       it "redirects to the new project" do
         post :create, params: {project: valid_params}
 
-        expect(response).to redirect_to "/projects"
+        expect(response).to redirect_to project_path(Project.last)
+      end
+
+      it "redirects to parent of new sub project" do
+        post :create, params: {project: valid_sub_proj_params}
+
+        expect(response).to redirect_to project_path(project)
       end
     end
 

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "managing projects", js: true do
         fill_in "project[title]", with: "Super Sub Project"
         click_button "Create"
         expect(page).to have_content "Project created!"
-        expect(current_path).to eq projects_path
+        expect(current_path).to eq project_path(id: project.id)
       end
 
       it "lists available sub projects with a link" do


### PR DESCRIPTION
### Jira Ticket 
https://ombulabs.atlassian.net/browse/ROAD-302

### Motivation / Context
Previously, when a project or sub project is being created, a redirect occurs to the projects index page. This fix introduces a redirect back to the project show page when both a new project or sub project have been created. 
    
### QA / Testing Instructions
To test this new feature:
1. Create a new project, confirm redirect to project show page
2. Create a new sub project, confirm redirect to parent projects show page

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).
