### PR TITLE
Add points edit feature

### DIFF
--- a/app/views/real_scores/edit.html.erb
+++ b/app/views/real_scores/edit.html.erb
@@ -1,9 +1,9 @@
 <div class="container">
   <h1 class="dashboard-title"><%= @project.title %> Real Scores</h1>
   <%= form_with scope: :stories, url: real_scores_project_stories_path(@project), method: :patch do |form| %>
-    
+
     <table class="project-table">
-      
+
       <thead>
         <tr class="project-table__row project-table__row--real-scores project-table__row--header">
           <td class="project-table__cell">Story Title</td>
@@ -20,7 +20,7 @@
               <td class="project-table__cell"><%= link_to story.title, [@project, story], target: "_blank" %></td>
               <td class="project-table__cell"><%= best_estimate_for_story(story) %></td>
               <td class="project-table__cell"><%= worst_estimate_for_story(story) %></td>
-              <td class="project-table__cell"><%= form.number_field "story_#{story.id}" %></td>
+              <td class="project-table__cell"><%= form.number_field "story_#{story.id}", value: "#{story.real_score}" %></td>
             </tr>
           <% end %>
         <% else %>
@@ -42,7 +42,5 @@
 
   <div class="btn-group">
     <%= link_to 'Back', reports_index_path, id:"back", class: "button" %>
-
-    <%= link_to 'Populate Real Scores', class: "button" %>
   </div>
 </div>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -67,7 +67,7 @@
 
   <div class="btn-group">
     <%= link_to 'Back', reports_index_path, id:"back", class: "button" %>
-    <%= link_to 'Populate Real Scores', real_scores_project_stories_path(@project), class: "button" %>
+    <%= link_to 'Edit Real Scores', real_scores_project_stories_path(@project), class: "button" %>
     <%= link_to_if @can_generate_estimate_report, 'Download Average Estimate Report', project_report_path(@project, format: 'csv'), class: "button" do %>
       Stories need at least 2 estimates to generate report
     <% end %>

--- a/spec/features/real_scores_manage_spec.rb
+++ b/spec/features/real_scores_manage_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe "managing real scores", js: true do
 
   it "allows me to edit a real score" do
     visit project_report_path(project.id)
-    click_link "Populate Real Scores"
+    click_link "Edit Real Scores"
+    expect(page).to have_field("stories[story_#{story.id}]", with: story.real_score.to_s)
     fill_in "stories[story_#{story.id}]", with: 5
     click_button "Submit"
     expect(story.reload.real_score).to eq 5


### PR DESCRIPTION
### Jira Ticket 
https://ombulabs.atlassian.net/browse/ROAD-307

### Motivation / Context
Before we completed this feature, to edit any existing real points required re-adding all existing real points instead of providing a pre-filled form with previous values to allow for a single real point change
    
### QA / Testing Instructions
1. Run `rails server` and sign in with an admin account
2. Navigate to project report page and click to `edit real scores` 
3. If there are existing real scores, the input field should be populated with the values
4. If no existing real scores, enter values and navigate back. Click on `edit real scores` to confirm values are retained

### Screenshots:
![image](https://user-images.githubusercontent.com/30131907/208532070-fb7d56f1-af83-4e8f-ab6c-314f35096d3e.png)

![image](https://user-images.githubusercontent.com/30131907/208532125-1e54e97d-3c77-4be2-b02f-bbb273af6cd8.png)

After submitting edits:

![image](https://user-images.githubusercontent.com/30131907/208532186-6cb82a4c-90c4-4348-8df8-876758f17e74.png)


___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).
