### PR TITLE
ROAD-540 Escape HTML in stories' description and extra info fields

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,8 @@ module ApplicationHelper
   OPTIONS = {
     hard_wrap: true,
     link_attributes: {rel: "nofollow", target: "_blank"},
-    no_intra_emphasis: true
+    no_intra_emphasis: true,
+    escape_html: true
   }.freeze
 
   EXTENSIONS = {


### PR DESCRIPTION
### Jira Ticket 

https://ombulabs.atlassian.net/browse/ROAD-540

### Motivation / Context

Fixes https://github.com/fastruby/points/issues/252

The solution was really simple, Redcarpet includes an option for the HTML parser to escape HTML and only parse markdown

### QA / Testing Instructions

Create/edit a story and write HTML code in the description or the extra info fields. The preview will display the code instead of rendering html tags.

### Screenshots:

Form:
![image](https://github.com/fastruby/points/assets/188464/512e2cc3-874f-4681-b917-7c68c96ddc27)

Show:
![image](https://github.com/fastruby/points/assets/188464/5d10a9af-156c-4e99-aa7a-6cf804692a04)

Action Plan output:
![image](https://github.com/fastruby/points/assets/188464/da54160d-01da-48ae-8614-3d360b38d01e)

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).
