### PR TITLE
ROAD-539 / Fix debounce of inputs' preview

### DIFF
--- a/app/assets/javascripts/stories.js
+++ b/app/assets/javascripts/stories.js
@@ -1,25 +1,28 @@
-document.addEventListener("input", (e) => {
-  const updateMarkdown = () => {
-    document.querySelectorAll("[data-has-preview]").forEach((element) => {
-      const form = element.closest("form");
-      const preview = form.querySelector(
-        "." + element.dataset.previewTarget + " .content"
-      );
-      if (preview) {
-        Rails.ajax({
-          type: "POST",
-          url: "/stories/render_markdown",
-          data: `markdown=${encodeURIComponent(element.value)}`,
-          dataType: "text",
-          success: (response) => {
-            preview.innerHTML = response;
-          },
-        });
-      }
-    });
-  };
+document.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll("[data-has-preview]").forEach((element) => {
+    let debounceTimer;
 
-  var debounceTimer;
-  window.clearTimeout(debounceTimer);
-  debounceTimer = window.setTimeout(updateMarkdown, 300);
+    element.addEventListener("input", (e) => {
+      const updateMarkdown = () => {
+        const form = element.closest("form");
+        const preview = form.querySelector(
+          "." + element.dataset.previewTarget + " .content"
+        );
+        if (preview) {
+          Rails.ajax({
+            type: "POST",
+            url: "/stories/render_markdown",
+            data: `markdown=${encodeURIComponent(element.value)}`,
+            dataType: "text",
+            success: (response) => {
+              preview.innerHTML = response;
+            },
+          });
+        }
+      };
+
+      window.clearTimeout(debounceTimer);
+      debounceTimer = window.setTimeout(updateMarkdown, 300);
+    });
+  });
 });


### PR DESCRIPTION
### Jira Ticket 

https://ombulabs.atlassian.net/browse/ROAD-539

### Motivation / Context

This PR fixes #250 

We have code to debounce the preview, but the code was not really doing a debounce, it was just delaying the requests but still doing all of them (and even doing extra requests since it was triggering the preview of the 2 inputs for any input change (even the title changing)).

This PR moves some things around to keep the debounceTimer in the right scope and to only update the preview of the text area that changed.
    
### QA / Testing Instructions

- Open a story edit/create form
- Open dev tools
- Start typing in the different inputs
- There should be only a few preview requests (to `/stories/render_markdown`) a moment after we stop typing instead of a request for each keystroke

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).
