### PR TITLE
ROAD-609: Export approved stories only

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -443,6 +443,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -90,7 +90,7 @@ class StoriesController < ApplicationController
     csv = if params[:export_with_comments] == "1"
       CSV.generate(headers: true) do |csv|
         csv << CSV_HEADERS + ["comment"]
-        @project.stories.includes(:comments).by_position.each do |story|
+        @project.stories.includes(:comments).approved.by_position.each do |story|
           comments = []
           story.comments.each do |comment|
             comments << "#{comment.user.name}: #{comment.body}"
@@ -101,7 +101,7 @@ class StoriesController < ApplicationController
     else
       CSV.generate(headers: true) do |csv|
         csv << CSV_HEADERS
-        @project.stories.by_position.each do |story|
+        @project.stories.approved.by_position.each do |story|
           csv << story.attributes.slice(*CSV_HEADERS)
         end
       end

--- a/spec/controllers/stories_controller_spec.rb
+++ b/spec/controllers/stories_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe StoriesController, type: :controller do
   render_views
 
   let!(:project) { FactoryBot.create(:project) }
-  let!(:story) { FactoryBot.create(:story, project: project) }
+  let!(:story) { FactoryBot.create(:story, project: project, status: :approved) }
 
   before do
     @request.env["devise.mapping"] = Devise.mappings[:user]
@@ -173,7 +173,9 @@ RSpec.describe StoriesController, type: :controller do
     end
 
     describe "#export" do
-      it "exports a CSV file" do
+      it "exports a CSV file with only approved stories" do
+        FactoryBot.create(:story, project: project, status: :rejected)
+        FactoryBot.create(:story, project: project, status: :pending)
         get :export, params: {project_id: project.id}
         expect(response).to have_http_status(:ok)
 
@@ -186,11 +188,13 @@ RSpec.describe StoriesController, type: :controller do
       end
 
       context "with comments" do
-        it "exports a CSV file" do
+        it "exports a CSV file with only approved stories" do
           user = FactoryBot.create(:user)
-          story2 = FactoryBot.create(:story, project: project)
-          story3 = FactoryBot.create(:story, project: project)
-          story4 = FactoryBot.create(:story, project: project)
+          story2 = FactoryBot.create(:story, project: project, status: :approved)
+          story3 = FactoryBot.create(:story, project: project, status: :approved)
+          story4 = FactoryBot.create(:story, project: project, status: :approved)
+          FactoryBot.create(:story, project: project, status: :rejected)
+          FactoryBot.create(:story, project: project, status: :pending)
           comment1 = FactoryBot.create(:comment, user: user, story: story)
           comment1_2 = FactoryBot.create(:comment, user: user, story: story)
           comment2_1 = FactoryBot.create(:comment, user: user, story: story2)

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -141,10 +141,12 @@ RSpec.describe "managing projects", js: true do
 
     context "import & Export" do
       before do
-        project.stories.create(title: "php upgrade", description: "quick php upgrade")
+        project.stories.create(title: "php upgrade", description: "quick php upgrade", status: :approved)
       end
 
       it "allows me to export a CSV", js: false do
+        project.stories.create(title: "pending story", description: "pending stories don't export", status: :pending)
+        project.stories.create(title: "rejected story", description: "rejected stories don't export", status: :rejected)
         visit project_path(id: project.id)
         find("#import-export").click
 


### PR DESCRIPTION
### Jira Ticket 
<!--- Add a link to the Jira ticket associated with this PR -->

See: https://ombulabs.atlassian.net/browse/ROAD-609


### Motivation / Context
<!--- Why is this change required? Summarize the changes you made.  -->
<!--- Describe the approach to solve the problem or complete the task -->

We use the CSV tool to export stories to Jira for example. We only want to work on stories that we approved and therefore we only want to export stories from Points that were approved.

    
### QA / Testing Instructions
<!--- List the steps required to review the changes locally or in staging -->
- Perform a CSV export in Points (without comments)
- Take note of the stories and their statuses
- Ensure that only the approved stories are present in the CSV file.
- Perform a CSV export in Points (with comments)
- Take note of the stories and their statuses
- Ensure that only the approved stories are present in the CSV file.

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).
