### PR TITLE
DT-457: Add ability to select all stories in a project

### DIFF
--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -1,28 +1,23 @@
 document.addEventListener("turbolinks:load", function () {
   $("input[name='stories[]']").click(() => {
-    const selected = $("input[name='stories[]']:checked");
-    const is_unlocked = $("#stories").data("unlocked");
-    if (!is_unlocked) {
-      return;
-    }
-
-    if (selected.length > 0) {
-      const ending = selected.length == 1 ? "y" : "ies";
-      $("#bulk_delete")
-        .text(`Bulk Delete (${selected.length} Stor${ending})`)
-        .attr("aria-disabled", "false")
-        .prop("disabled", false);
-    } else {
-      $("#bulk_delete")
-        .text("Bulk Delete")
-        .attr("aria-disabled", "true")
-        .prop("disabled", true);
-    }
+    updateBulkDeleteStatus();
   });
+
 
   $(".import-export-header").click(function () {
     $(this).children(".rotate").toggleClass("left");
   });
+
+
+  $("#select_all").click((event) => {
+    let checked = event.target.checked;
+
+    $("input[name='stories[]']").each((_, checkbox) => {
+      checkbox.checked = checked;
+    })
+
+    updateBulkDeleteStatus();
+  })
 
   $("#bulk_delete").click((event) => {
     let stories_ids = [];
@@ -117,4 +112,25 @@ function toggleCloneSubProjects(value) {
   document
     .querySelectorAll("#sub-projects-to-clone input[type='checkbox']")
     .forEach((el) => (el.checked = value));
+}
+
+function updateBulkDeleteStatus() {
+  const selected = $("input[name='stories[]']:checked");
+    const is_unlocked = $("#stories").data("unlocked");
+    if (!is_unlocked) {
+      return;
+    }
+
+    if (selected.length > 0) {
+      const ending = selected.length == 1 ? "y" : "ies";
+      $("#bulk_delete")
+        .text(`Bulk Delete (${selected.length} Stor${ending})`)
+        .attr("aria-disabled", "false")
+        .prop("disabled", false);
+    } else {
+      $("#bulk_delete")
+        .text("Bulk Delete")
+        .attr("aria-disabled", "true")
+        .prop("disabled", true);
+    }
 }

--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -1,6 +1,7 @@
 document.addEventListener("turbolinks:load", function () {
   $("input[name='stories[]']").click(() => {
     updateBulkDeleteStatus();
+    updateSelectAllStatus();
   });
 
 
@@ -133,4 +134,20 @@ function updateBulkDeleteStatus() {
         .attr("aria-disabled", "true")
         .prop("disabled", true);
     }
+}
+
+function updateSelectAllStatus() {
+  const selected = $("input[name='stories[]']:checked");
+  const checkboxes = $("input[name='stories[]']");
+
+  if (selected.length == 0) {
+    $("#select_all")[0].checked = false;
+    $("#select_all")[0].indeterminate = false;
+  } else if (selected.length == checkboxes.length) {
+    $("#select_all")[0].checked = true;
+    $("#select_all")[0].indeterminate = false;
+  } else {
+    $("#select_all")[0].checked = false;
+    $("#select_all")[0].indeterminate = true;
+  }
 }

--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -4,11 +4,9 @@ document.addEventListener("turbolinks:load", function () {
     updateSelectAllStatus();
   });
 
-
   $(".import-export-header").click(function () {
     $(this).children(".rotate").toggleClass("left");
   });
-
 
   $("#select_all").click((event) => {
     let checked = event.target.checked;
@@ -117,37 +115,44 @@ function toggleCloneSubProjects(value) {
 
 function updateBulkDeleteStatus() {
   const selected = $("input[name='stories[]']:checked");
-    const is_unlocked = $("#stories").data("unlocked");
-    if (!is_unlocked) {
-      return;
-    }
+  const is_unlocked = $("#stories").data("unlocked");
+  if (!is_unlocked) {
+    return;
+  }
 
-    if (selected.length > 0) {
-      const ending = selected.length == 1 ? "y" : "ies";
-      $("#bulk_delete")
-        .text(`Bulk Delete (${selected.length} Stor${ending})`)
-        .attr("aria-disabled", "false")
-        .prop("disabled", false);
-    } else {
-      $("#bulk_delete")
-        .text("Bulk Delete")
-        .attr("aria-disabled", "true")
-        .prop("disabled", true);
-    }
+  if (selected.length > 0) {
+    const ending = selected.length == 1 ? "y" : "ies";
+    $("#bulk_delete")
+      .text(`Bulk Delete (${selected.length} Stor${ending})`)
+      .attr("aria-disabled", "false")
+      .prop("disabled", false);
+  } else {
+    $("#bulk_delete")
+      .text("Bulk Delete")
+      .attr("aria-disabled", "true")
+      .prop("disabled", true);
+  }
 }
 
 function updateSelectAllStatus() {
+  const selectAll = $("#select_all")[0];
+  // Select All is only rendered for unlocked projects, so there is nothing to
+  // sync when it is absent.
+  if (!selectAll) {
+    return;
+  }
+
   const selected = $("input[name='stories[]']:checked");
   const checkboxes = $("input[name='stories[]']");
 
   if (selected.length == 0) {
-    $("#select_all")[0].checked = false;
-    $("#select_all")[0].indeterminate = false;
+    selectAll.checked = false;
+    selectAll.indeterminate = false;
   } else if (selected.length == checkboxes.length) {
-    $("#select_all")[0].checked = true;
-    $("#select_all")[0].indeterminate = false;
+    selectAll.checked = true;
+    selectAll.indeterminate = false;
   } else {
-    $("#select_all")[0].checked = false;
-    $("#select_all")[0].indeterminate = true;
+    selectAll.checked = false;
+    selectAll.indeterminate = true;
   }
 }

--- a/app/assets/javascripts/project.js
+++ b/app/assets/javascripts/project.js
@@ -97,7 +97,7 @@ const filterStories = () => {
   document.querySelectorAll("#stories tr").forEach(function (element) {
     const cl = element.classList;
     const storyTitle = element
-      .querySelector("td:first-child")
+      .querySelector("td:nth-child(2)")
       .innerText.toLowerCase();
     if (storyTitle.includes(searchTerm) || element.id.replace(/\D/g, '').includes(searchTerm)) {
       cl.remove("hidden");

--- a/app/assets/stylesheets/4-molecules/_tables.scss
+++ b/app/assets/stylesheets/4-molecules/_tables.scss
@@ -11,9 +11,15 @@
   }
   .project-table__row {
     display: grid;
-    grid-template-columns: 1fr 100px 70px 70px 260px;
+    grid-template-columns: 120px 1fr 100px 70px 70px 260px;
     align-items: center;
     padding: 10px 0;
+    .select-all-cell {
+      text-align: center;
+      label {
+        font-weight: bold;
+      }
+    }
     &.project-table__row--reports {
       display: flex;
       flex-direction: row;

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -18,6 +18,10 @@
             <th class="project-table__cell">Best<br />Estimate</th>
             <th class="project-table__cell">Worst<br />Estimate</th>
             <th class="project-table__cell story_actions">
+              <div>
+                <input type="checkbox" name="select_all" id="select_all">
+                <label for="select_all">Select All</label>
+              </div>
               <%= link_unless_archived(@project, "Add a Story", new_project_story_path(@project), classes: "green") if is_unlocked?(@project) %>
               <button id="bulk_delete" class="button magenta" aria-disabled="true" disabled>Bulk Delete</button>
             </th>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -13,17 +13,17 @@
       <table class="project-table">
         <thead class="table-header fixed-header">
           <tr class="project-table__row project-table__row--header">
+            <th class="project-table__cell select-all-cell">
+              <% if is_unlocked?(@project) %>
+                <label for="select_all">Select All</label>
+                <input type="checkbox" name="select_all" id="select_all">
+              <% end %>
+            </th>
             <th class="project-table__cell">Story Title</th>
             <th class="project-table__cell">Status</th>
             <th class="project-table__cell">Best<br />Estimate</th>
             <th class="project-table__cell">Worst<br />Estimate</th>
             <th class="project-table__cell story_actions">
-              <% if is_unlocked?(@project) %>
-                <div>
-                  <input type="checkbox" name="select_all" id="select_all">
-                  <label for="select_all">Select All</label>
-                </div>
-              <% end %>
               <%= link_unless_archived(@project, "Add a Story", new_project_story_path(@project), classes: "green") if is_unlocked?(@project) %>
               <button id="bulk_delete" class="button magenta" aria-disabled="true" disabled>Bulk Delete</button>
             </th>
@@ -33,9 +33,11 @@
           <% if @stories.present? %>
             <% @stories.each do | story | %>
               <tr class="project-table__row project-table__row--story" id="<%= dom_id(story)%>" data-status="<%= story.status %>">
+                <td class="project-table__cell select-all-cell">
+                  <input type="checkbox" name="stories[]" value="<%= story.id %>">
+                </td>
                 <td class="project-table__cell">
                   <span class="popup">Copied to clipboard</span>
-                  <input type="checkbox" name="stories[]" value="<%= story.id %>">
                   <%= link_to "#{story.id} - #{story.title}", [story.project, story] %>
                 </td>
                 <td class="project-table__cell status"><%= status_label(story) %></td>
@@ -88,6 +90,7 @@
         </tbody>
         <tfoot>
           <tr class="project-table__row project-table__row--footer">
+            <td class="project-table__cell"></td>
             <td class="project-table__cell">Total estimates</td>
             <td class="project-table__cell"></td>
             <td class="project-table__cell best_estimates_total"><%= @project.best_estimate_sum_per_user(current_user) %></td>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -18,10 +18,12 @@
             <th class="project-table__cell">Best<br />Estimate</th>
             <th class="project-table__cell">Worst<br />Estimate</th>
             <th class="project-table__cell story_actions">
-              <div>
-                <input type="checkbox" name="select_all" id="select_all">
-                <label for="select_all">Select All</label>
-              </div>
+              <% if is_unlocked?(@project) %>
+                <div>
+                  <input type="checkbox" name="select_all" id="select_all">
+                  <label for="select_all">Select All</label>
+                </div>
+              <% end %>
               <%= link_unless_archived(@project, "Add a Story", new_project_story_path(@project), classes: "green") if is_unlocked?(@project) %>
               <button id="bulk_delete" class="button magenta" aria-disabled="true" disabled>Bulk Delete</button>
             </th>

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -123,6 +123,15 @@ RSpec.describe "managing stories", js: true do
     expect(page).to have_unchecked_field(name: "stories[]")
   end
 
+  it "does not show Select All on a locked project" do
+    locked_project = FactoryBot.create(:project, :locked)
+    FactoryBot.create(:story, project: locked_project)
+
+    visit project_path(id: locked_project.id)
+
+    expect(page).to have_no_field("Select All")
+  end
+
   it "allows me to delete a story" do
     visit project_path(id: project.id)
 

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -108,6 +108,21 @@ RSpec.describe "managing stories", js: true do
     assert_current_path project_path(id: project.id)
   end
 
+  it "allows me to select all stories" do
+    visit project_path(id: project.id)
+    check("Select All")
+
+    expect(page).to have_checked_field(name: "stories[]")
+  end
+
+  it "allows me to unselect all stories" do
+    visit project_path(id: project.id)
+    check("Select All")
+    uncheck("Select All")
+
+    expect(page).to have_unchecked_field(name: "stories[]")
+  end
+
   it "allows me to delete a story" do
     visit project_path(id: project.id)
 

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -132,6 +132,16 @@ RSpec.describe "managing stories", js: true do
     expect(page).to have_no_field("Select All")
   end
 
+  it "keeps Bulk Delete disabled on a locked project even when a story is selected" do
+    locked_project = FactoryBot.create(:project, :locked)
+    FactoryBot.create(:story, project: locked_project)
+
+    visit project_path(id: locked_project.id)
+    find("input[name='stories[]']", match: :first).check
+
+    expect(page).to have_selector("#bulk_delete[disabled]")
+  end
+
   it "allows me to delete a story" do
     visit project_path(id: project.id)
 

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -430,14 +430,14 @@ RSpec.describe "managing stories", js: true do
     fill_in "title_contains", with: "XYZ"
 
     within("#stories") do
-      expect(find("td:nth-child(1)")).to have_text story4.title
+      expect(find("td:nth-child(2)")).to have_text story4.title
       expect(all("#stories > tr").count).to eq(1)
     end
 
     fill_in "title_contains", with: story5.id
 
     within("#stories") do
-      expect(find("td:nth-child(1)")).to have_text story5.title
+      expect(find("td:nth-child(2)")).to have_text story5.title
       expect(all("#stories > tr").count).to eq(1)
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,8 +63,8 @@ module FeatureSpecsHelpers
 
   def expect_story_estimates(story, best, worst)
     within_story_row(story) do
-      expect(find("td:nth-child(3)")).to have_text best.to_s
-      expect(find("td:nth-child(4)")).to have_text worst.to_s
+      expect(find("td:nth-child(4)")).to have_text best.to_s
+      expect(find("td:nth-child(5)")).to have_text worst.to_s
     end
   end
 end


### PR DESCRIPTION
### Jira Ticket 
See https://ombulabs.atlassian.net/browse/DT-457

### Motivation / Context

In a Points project, stories need to be selected individually. There is no option to select all. There should be a Select All option to be able to easily perform bulk actions.

### QA / Testing Instructions
1. Go to a project with stories
2. Check the Select All checkbox
3. Ensure that all stories are selected and Bulk Delete button becomes enabled and shows the number of all stories selected
4. Unselect the Select All checkbox
5. Ensure that no stories are selected and the Bulk Delete button is disabled


### Screenshots:
<img width="1236" alt="Screenshot 2024-10-21 at 10 07 19 AM" src="https://github.com/user-attachments/assets/866a8f33-e609-4cfe-b100-c1bb78062777">
<img width="1236" alt="Screenshot 2024-10-21 at 10 07 12 AM" src="https://github.com/user-attachments/assets/a2d24fdf-552e-42e3-b259-a37b1f7d7e40">

Note:

* `app/models/user.rb` was changed here because there were some linting issues standardrb wouldn’t let me commit without. 
* I also realize the CI for this is failing - I did add a PR for this change in another PR https://github.com/fastruby/points/pull/332 and then cherry-picked the change in this PR to ensure CI passed.

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).
