### PR TITLE
DT-459: Updates upload-artifact

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Run RSpec
         run: |
           bundle exec rspec
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Screenshots and logs

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,5 +3,4 @@ class User < ApplicationRecord
 
   has_many :estimates
   has_many :comments
-
 end


### PR DESCRIPTION
### Jira Ticket 
https://ombulabs.atlassian.net/browse/DT-459

### Motivation / Context
My last PR failed due to `actions/upload-artifact: v2` being deprecated:
https://github.com/fastruby/points/actions/runs/11441953756/job/31831210476?pr=331

I am updating `upload-artifact: v2` to see if this fixes the failure in the test suite. I am updating to version 4 specifically since version 3 will be deprecated by the end of November: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/.

Note: I know that the `build-next-rails` job still fails, as that job is running Rails 8.1.alpha.

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).
