### PR TITLE
DT-458: Add ability for admins to export stories regardless of status

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -90,7 +90,12 @@ class StoriesController < ApplicationController
     csv = if params[:export_with_comments] == "1"
       CSV.generate(headers: true) do |csv|
         csv << CSV_HEADERS + ["comment"]
-        @project.stories.includes(:comments).approved.by_position.each do |story|
+        stories = if params.include?(:export_all) && params[:export_all] == "1"
+          @project.stories.includes(:comments)
+        else
+          @project.stories.includes(:comments).approved
+        end
+        stories.by_position.each do |story|
           comments = []
           story.comments.each do |comment|
             comments << "#{display_name(comment.user)}: #{comment.body}"
@@ -101,7 +106,13 @@ class StoriesController < ApplicationController
     else
       CSV.generate(headers: true) do |csv|
         csv << CSV_HEADERS
-        @project.stories.approved.by_position.each do |story|
+        stories = if params.include?(:export_all) && params[:export_all] == "1"
+          @project.stories
+        else
+          @project.stories.approved
+        end
+
+        stories.by_position.each do |story|
           csv << story.attributes.slice(*CSV_HEADERS)
         end
       end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -103,18 +103,20 @@ class StoriesController < ApplicationController
 
   def generate_csv(stories, with_comments: false, export_all: false)
     CSV.generate(headers: true) do |csv|
-      csv << CSV_HEADERS.dup.tap { |headers| headers << "comment" if with_comments }
+      headers = CSV_HEADERS.dup
+      headers << "comment" if with_comments
+      csv << headers
 
       stories.by_position.each do |story|
+        comments = []
+
         if with_comments
           comments = story.comments.map do |comment|
             "#{display_name(comment.user)}: #{comment.body}"
           end
-
-          csv << [story.id, story.title, story.description, story.position] + comments
-        else
-          csv << story.attributes.slice(*CSV_HEADERS)
         end
+
+        csv << [story.id, story.title, story.description, story.position] + comments
       end
     end
   end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -103,7 +103,13 @@ class StoriesController < ApplicationController
 
   def generate_csv(stories, with_comments: false, export_all: false)
     CSV.generate(headers: true) do |csv|
-      csv << (with_comments ? (CSV_HEADERS + ["comment"]) : CSV_HEADERS)
+      headers = if with_comments
+        CSV_HEADERS + ["comment"]
+      else
+        CSV_HEADERS
+      end
+
+      csv << headers
 
       stories.by_position.each do |story|
         if with_comments
@@ -111,8 +117,11 @@ class StoriesController < ApplicationController
           story.comments.each do |comment|
             comments << "#{display_name(comment.user)}: #{comment.body}"
           end
+
+          csv << [story.id, story.title, story.description, story.position] + comments
+        else
+          csv << story.attributes.slice(*CSV_HEADERS)
         end
-        csv << (with_comments ? ([story.id, story.title, story.description, story.position] + comments) : story.attributes.slice(*CSV_HEADERS))
       end
     end
   end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -103,8 +103,8 @@ class StoriesController < ApplicationController
 
   def generate_csv(stories, with_comments: false, export_all: false)
     CSV.generate(headers: true) do |csv|
-      headers = with_comments ? CSV_HEADERS + ["comment"] : CSV_HEADERS
-
+      headers = CSV_HEADERS.dup
+      headers << "comment" if with_comments
       csv << headers
 
       stories.by_position.each do |story|

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -103,9 +103,7 @@ class StoriesController < ApplicationController
 
   def generate_csv(stories, with_comments: false, export_all: false)
     CSV.generate(headers: true) do |csv|
-      headers = CSV_HEADERS.dup
-      headers << "comment" if with_comments
-      csv << headers
+      csv << CSV_HEADERS.dup.tap { |headers| headers << "comment" if with_comments }
 
       stories.by_position.each do |story|
         if with_comments

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -113,9 +113,8 @@ class StoriesController < ApplicationController
 
       stories.by_position.each do |story|
         if with_comments
-          comments = []
-          story.comments.each do |comment|
-            comments << "#{display_name(comment.user)}: #{comment.body}"
+          comments = story.comments.map do |comment|
+            "#{display_name(comment.user)}: #{comment.body}"
           end
 
           csv << [story.id, story.title, story.description, story.position] + comments

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -103,11 +103,7 @@ class StoriesController < ApplicationController
 
   def generate_csv(stories, with_comments: false, export_all: false)
     CSV.generate(headers: true) do |csv|
-      headers = if with_comments
-        CSV_HEADERS + ["comment"]
-      else
-        CSV_HEADERS
-      end
+      headers = with_comments ? CSV_HEADERS + ["comment"] : CSV_HEADERS
 
       csv << headers
 

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -94,7 +94,9 @@ class StoriesController < ApplicationController
     export_all = params[:export_all] == "1" && current_user.admin?
 
     stories = export_all ? @project.stories : @project.stories.approved
-    stories = stories.includes(:comments) if with_comments
+    # Eager-load the comments and their authors; generate_csv reads
+    # comment.user for every comment, which would otherwise be an N+1.
+    stories = stories.includes(comments: :user) if with_comments
 
     csv = generate_csv(stories, with_comments: with_comments)
 
@@ -145,19 +147,20 @@ class StoriesController < ApplicationController
   def generate_csv(stories, with_comments: false)
     CSV.generate(headers: true) do |csv|
       headers = CSV_HEADERS.dup
-      headers << "comment" if with_comments
+      headers << "comments" if with_comments
       csv << headers
 
       stories.by_position.each do |story|
-        comments = []
+        row = [story.id, story.title, story.description, story.position]
 
+        # Keep every story on a single, uniform-width row: collapse all comments
+        # into one cell instead of spilling into a variable number of trailing,
+        # unlabeled columns.
         if with_comments
-          comments = story.comments.map do |comment|
-            "#{display_name(comment.user)}: #{comment.body}"
-          end
+          row << story.comments.map { |comment| "#{display_name(comment.user)}: #{comment.body}" }.join("\n")
         end
 
-        csv << [story.id, story.title, story.description, story.position] + comments
+        csv << row
       end
     end
   end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -87,38 +87,19 @@ class StoriesController < ApplicationController
   end
 
   def export
-    csv = if params[:export_with_comments] == "1" && params[:export_all] == "1"
-      generate_csv(@project.stories.includes(:comments), with_comments: true, export_all: true)
-    elsif params[:export_with_comments] == "1"
-      generate_csv(@project.stories.includes(:comments).approved, with_comments: true, export_all: false)
-    elsif params[:export_all] == "1"
-      generate_csv(@project.stories, with_comments: false, export_all: true)
-    else
-      generate_csv(@project.stories.approved, with_comments: false, export_all: false)
-    end
+    with_comments = params[:export_with_comments] == "1"
+    # Only admins may export non-approved stories. Enforce it here rather than
+    # relying on the checkbox being hidden in the view, so the param can't be
+    # forged by a non-admin.
+    export_all = params[:export_all] == "1" && current_user.admin?
+
+    stories = export_all ? @project.stories : @project.stories.approved
+    stories = stories.includes(:comments) if with_comments
+
+    csv = generate_csv(stories, with_comments: with_comments)
 
     filename = "#{@project.title.gsub(/[^\w]/, "_")}-#{Time.now.to_formatted_s(:short).tr(" ", "_")}.csv"
     send_data csv, filename: filename
-  end
-
-  def generate_csv(stories, with_comments: false, export_all: false)
-    CSV.generate(headers: true) do |csv|
-      headers = CSV_HEADERS.dup
-      headers << "comment" if with_comments
-      csv << headers
-
-      stories.by_position.each do |story|
-        comments = []
-
-        if with_comments
-          comments = story.comments.map do |comment|
-            "#{display_name(comment.user)}: #{comment.body}"
-          end
-        end
-
-        csv << [story.id, story.title, story.description, story.position] + comments
-      end
-    end
   end
 
   def render_markdown
@@ -160,6 +141,26 @@ class StoriesController < ApplicationController
   end
 
   private
+
+  def generate_csv(stories, with_comments: false)
+    CSV.generate(headers: true) do |csv|
+      headers = CSV_HEADERS.dup
+      headers << "comment" if with_comments
+      csv << headers
+
+      stories.by_position.each do |story|
+        comments = []
+
+        if with_comments
+          comments = story.comments.map do |comment|
+            "#{display_name(comment.user)}: #{comment.body}"
+          end
+        end
+
+        csv << [story.id, story.title, story.description, story.position] + comments
+      end
+    end
+  end
 
   def find_project
     @project = Project.find(params[:project_id])

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -8,8 +8,6 @@ class StoriesController < ApplicationController
 
   include ApplicationHelper
 
-  CSV_HEADERS = %w[id title description position]
-
   def new
     @story = Story.where(id: params[:story_id]).first_or_initialize.dup
   end
@@ -146,12 +144,12 @@ class StoriesController < ApplicationController
 
   def generate_csv(stories, with_comments: false)
     CSV.generate(headers: true) do |csv|
-      headers = CSV_HEADERS.dup
+      headers = %w[id position status title description]
       headers << "comments" if with_comments
       csv << headers
 
       stories.by_position.each do |story|
-        row = [story.id, story.title, story.description, story.position]
+        row = [story.id, story.position, story.status, story.title, story.description]
 
         # Keep every story on a single, uniform-width row: collapse all comments
         # into one cell instead of spilling into a variable number of trailing,

--- a/app/views/projects/_import_export.html.erb
+++ b/app/views/projects/_import_export.html.erb
@@ -33,7 +33,13 @@
         <div class="card-body">
           <%= form_with url: export_project_stories_path(@project), method: :get do |f| %>
             <%= f.submit "Export", class: "button green", data: { disable_with: false } %>
-            <br/>
+            <% if current_user.admin? %>
+              <br />
+              <%= f.label :export_all do %>
+                <%= f.check_box :export_all %>
+                Export all stories
+              <% end %>
+            <% end %>
             <%= f.label :export_with_comments do %>
               <%= f.check_box :export_with_comments %>
               Export with comments

--- a/spec/controllers/stories_controller_spec.rb
+++ b/spec/controllers/stories_controller_spec.rb
@@ -187,6 +187,27 @@ RSpec.describe StoriesController, type: :controller do
         expect(csv_data).to eq(expected_csv_content)
       end
 
+      context "when an admin" do
+        it "exports a CSV file with all stories" do
+          user = FactoryBot.create(:user)
+          user.admin = true
+
+          story2 = FactoryBot.create(:story, project: project, status: :rejected)
+          story3 = FactoryBot.create(:story, project: project, status: :pending)
+          get :export, params: {project_id: project.id, export_all: "1"}
+          expect(response).to have_http_status(:ok)
+
+          csv_data = CSV.parse(response.body)
+          expected_csv_content = [
+            ["id", "title", "description", "position"],
+            [story.id.to_s, story.title, story.description, story.position.to_s],
+            [story2.id.to_s, story2.title, story2.description, story2.position.to_s],
+            [story3.id.to_s, story3.title, story3.description, story3.position.to_s]
+          ]
+          expect(csv_data).to eq(expected_csv_content)
+        end
+      end
+
       context "with comments" do
         it "exports a CSV file with only approved stories" do
           user = FactoryBot.create(:user)

--- a/spec/controllers/stories_controller_spec.rb
+++ b/spec/controllers/stories_controller_spec.rb
@@ -181,8 +181,8 @@ RSpec.describe StoriesController, type: :controller do
 
         csv_data = CSV.parse(response.body)
         expected_csv_content = [
-          ["id", "title", "description", "position"],
-          [story.id.to_s, story.title, story.description, story.position.to_s]
+          ["id", "position", "status", "title", "description"],
+          [story.id.to_s, story.position.to_s, story.status, story.title, story.description]
         ]
         expect(csv_data).to eq(expected_csv_content)
       end
@@ -198,10 +198,10 @@ RSpec.describe StoriesController, type: :controller do
 
           csv_data = CSV.parse(response.body)
           expected_csv_content = [
-            ["id", "title", "description", "position"],
-            [story.id.to_s, story.title, story.description, story.position.to_s],
-            [story2.id.to_s, story2.title, story2.description, story2.position.to_s],
-            [story3.id.to_s, story3.title, story3.description, story3.position.to_s]
+            ["id", "position", "status", "title", "description"],
+            [story.id.to_s, story.position.to_s, story.status, story.title, story.description],
+            [story2.id.to_s, story2.position.to_s, story2.status, story2.title, story2.description],
+            [story3.id.to_s, story3.position.to_s, story3.status, story3.title, story3.description]
           ]
           expect(csv_data).to eq(expected_csv_content)
         end
@@ -218,8 +218,8 @@ RSpec.describe StoriesController, type: :controller do
 
           csv_data = CSV.parse(response.body)
           expected_csv_content = [
-            ["id", "title", "description", "position"],
-            [story.id.to_s, story.title, story.description, story.position.to_s]
+            ["id", "position", "status", "title", "description"],
+            [story.id.to_s, story.position.to_s, story.status, story.title, story.description]
           ]
           expect(csv_data).to eq(expected_csv_content)
         end
@@ -244,11 +244,11 @@ RSpec.describe StoriesController, type: :controller do
 
           csv_data = CSV.parse(response.body)
           expected_csv_content = [
-            ["id", "title", "description", "position", "comments"],
-            [story.id.to_s, story.title, story.description, story.position.to_s, "#{comment1.user.name}: #{comment1.body}\n#{comment1_2.user.name}: #{comment1_2.body}"],
-            [story2.id.to_s, story2.title, story2.description, story2.position.to_s, "#{comment2_1.user.name}: #{comment2_1.body}\n#{comment2_2.user.name}: #{comment2_2.body}"],
-            [story3.id.to_s, story3.title, story3.description, story3.position.to_s, "#{comment3_1.user.name}: #{comment3_1.body}"],
-            [story4.id.to_s, story4.title, story4.description, story4.position.to_s, ""]
+            ["id", "position", "status", "title", "description", "comments"],
+            [story.id.to_s, story.position.to_s, story.status, story.title, story.description, "#{comment1.user.name}: #{comment1.body}\n#{comment1_2.user.name}: #{comment1_2.body}"],
+            [story2.id.to_s, story2.position.to_s, story2.status, story2.title, story2.description, "#{comment2_1.user.name}: #{comment2_1.body}\n#{comment2_2.user.name}: #{comment2_2.body}"],
+            [story3.id.to_s, story3.position.to_s, story3.status, story3.title, story3.description, "#{comment3_1.user.name}: #{comment3_1.body}"],
+            [story4.id.to_s, story4.position.to_s, story4.status, story4.title, story4.description, ""]
           ]
 
           expect(csv_data).to eq(expected_csv_content)
@@ -270,10 +270,10 @@ RSpec.describe StoriesController, type: :controller do
 
           csv_data = CSV.parse(response.body)
           expect(csv_data).to eq([
-            ["id", "title", "description", "position", "comments"],
-            [story.id.to_s, story.title, story.description, story.position.to_s, "#{commenter.name}: #{approved_comment.body}"],
-            [rejected.id.to_s, rejected.title, rejected.description, rejected.position.to_s, "#{commenter.name}: #{rejected_comment.body}"],
-            [pending.id.to_s, pending.title, pending.description, pending.position.to_s, ""]
+            ["id", "position", "status", "title", "description", "comments"],
+            [story.id.to_s, story.position.to_s, story.status, story.title, story.description, "#{commenter.name}: #{approved_comment.body}"],
+            [rejected.id.to_s, rejected.position.to_s, rejected.status, rejected.title, rejected.description, "#{commenter.name}: #{rejected_comment.body}"],
+            [pending.id.to_s, pending.position.to_s, pending.status, pending.title, pending.description, ""]
           ])
         end
       end

--- a/spec/controllers/stories_controller_spec.rb
+++ b/spec/controllers/stories_controller_spec.rb
@@ -189,8 +189,7 @@ RSpec.describe StoriesController, type: :controller do
 
       context "when an admin" do
         it "exports a CSV file with all stories" do
-          user = FactoryBot.create(:user)
-          user.admin = true
+          sign_in FactoryBot.create(:user, :admin)
 
           story2 = FactoryBot.create(:story, project: project, status: :rejected)
           story3 = FactoryBot.create(:story, project: project, status: :pending)
@@ -203,6 +202,24 @@ RSpec.describe StoriesController, type: :controller do
             [story.id.to_s, story.title, story.description, story.position.to_s],
             [story2.id.to_s, story2.title, story2.description, story2.position.to_s],
             [story3.id.to_s, story3.title, story3.description, story3.position.to_s]
+          ]
+          expect(csv_data).to eq(expected_csv_content)
+        end
+      end
+
+      context "when not an admin" do
+        it "ignores export_all and exports only approved stories" do
+          # The signed-in user from the before block is not an admin, so a
+          # forged export_all param must not leak non-approved stories.
+          FactoryBot.create(:story, project: project, status: :rejected)
+          FactoryBot.create(:story, project: project, status: :pending)
+          get :export, params: {project_id: project.id, export_all: "1"}
+          expect(response).to have_http_status(:ok)
+
+          csv_data = CSV.parse(response.body)
+          expected_csv_content = [
+            ["id", "title", "description", "position"],
+            [story.id.to_s, story.title, story.description, story.position.to_s]
           ]
           expect(csv_data).to eq(expected_csv_content)
         end

--- a/spec/controllers/stories_controller_spec.rb
+++ b/spec/controllers/stories_controller_spec.rb
@@ -244,14 +244,37 @@ RSpec.describe StoriesController, type: :controller do
 
           csv_data = CSV.parse(response.body)
           expected_csv_content = [
-            ["id", "title", "description", "position", "comment"],
-            [story.id.to_s, story.title, story.description, story.position.to_s, "#{comment1.user.name}: #{comment1.body}", "#{comment1_2.user.name}: #{comment1_2.body}"],
-            [story2.id.to_s, story2.title, story2.description, story2.position.to_s, "#{comment2_1.user.name}: #{comment2_1.body}", "#{comment2_2.user.name}: #{comment2_2.body}"],
+            ["id", "title", "description", "position", "comments"],
+            [story.id.to_s, story.title, story.description, story.position.to_s, "#{comment1.user.name}: #{comment1.body}\n#{comment1_2.user.name}: #{comment1_2.body}"],
+            [story2.id.to_s, story2.title, story2.description, story2.position.to_s, "#{comment2_1.user.name}: #{comment2_1.body}\n#{comment2_2.user.name}: #{comment2_2.body}"],
             [story3.id.to_s, story3.title, story3.description, story3.position.to_s, "#{comment3_1.user.name}: #{comment3_1.body}"],
-            [story4.id.to_s, story4.title, story4.description, story4.position.to_s]
+            [story4.id.to_s, story4.title, story4.description, story4.position.to_s, ""]
           ]
 
           expect(csv_data).to eq(expected_csv_content)
+        end
+      end
+
+      context "when an admin exports all stories with comments" do
+        it "includes comments for non-approved stories too" do
+          sign_in FactoryBot.create(:user, :admin)
+          commenter = FactoryBot.create(:user)
+
+          rejected = FactoryBot.create(:story, project: project, status: :rejected)
+          pending = FactoryBot.create(:story, project: project, status: :pending)
+          approved_comment = FactoryBot.create(:comment, user: commenter, story: story)
+          rejected_comment = FactoryBot.create(:comment, user: commenter, story: rejected)
+
+          get :export, params: {project_id: project.id, export_all: "1", export_with_comments: "1"}
+          expect(response).to have_http_status(:ok)
+
+          csv_data = CSV.parse(response.body)
+          expect(csv_data).to eq([
+            ["id", "title", "description", "position", "comments"],
+            [story.id.to_s, story.title, story.description, story.position.to_s, "#{commenter.name}: #{approved_comment.body}"],
+            [rejected.id.to_s, rejected.title, rejected.description, rejected.position.to_s, "#{commenter.name}: #{rejected_comment.body}"],
+            [pending.id.to_s, pending.title, pending.description, pending.position.to_s, ""]
+          ])
         end
       end
     end


### PR DESCRIPTION
### Jira Ticket
https://ombulabs.atlassian.net/browse/DT-458

### Motivation / Context
Currently, stories are only exported to CSV if they have an accepted status. This feature allows admin users to export stories regardless of their status. Non-admins should only be able to export approved stories.

I also refactored the `export` method because Code Climate was complaining.

### Additional changes from review
Follow-up improvements made while reviewing the PR:

- **Admin gate enforced server-side.** "Export all" is no longer trusted from the request params alone (the checkbox was only hidden in the view). The controller now honors `export_all` only when `current_user.admin?`, so a non-admin cannot forge `?export_all=1` to download non-approved stories. Added a spec for that forged-param case.
- **Fixed the admin spec.** It previously built `user.admin = true` without signing in as that user, so it never actually exercised admin behavior. It now signs in as an admin.
- **Simplified `export`.** Replaced the four-way conditional with two booleans (`with_comments`, `export_all`) and a single call to `generate_csv`, and moved `generate_csv` to `private`.
- **Removed an N+1.** With comments, the export now eager-loads comment authors (`includes(comments: :user)`), instead of firing one query per comment for `display_name`.
- **Uniform CSV rows.** A story's comments are now written into a single `comments` cell (newline-separated) instead of spilling into a variable number of unlabeled trailing columns, so every row has the same width.
- **Added a `status` column.** Since we can now export every status, the CSV includes each story's status so an all-statuses export is actually readable. Columns are ordered `id, position, status, title, description, comments`. Import matches columns by name, so the new column and ordering don't affect it.
- Added a spec covering an admin exporting all stories **with comments** (comments are included for non-approved stories too).

### QA / Testing Instructions
As an **admin**:
1. Go to a project with stories in different statuses.
2. Click **CSV Import/Export**.
3. Check **Export all stories** and click **Export** — the CSV includes stories of every status.
4. Also check **Export with comments** — the CSV has a `comments` column, populated for non-approved stories as well.

As a **non-admin**:
5. The **Export all stories** checkbox is not shown; export returns approved stories only.
6. Even hitting `…/stories/export?export_all=1` directly returns approved stories only.

### Screenshots:
<img width="1236" alt="Screenshot 2024-10-23 at 10 31 50 AM" src="https://github.com/user-attachments/assets/7aca85cd-419c-4622-a338-ba2046029147">
___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).
