### PR TITLE
DT-340: Warn the user if they are leaving a story edit page with unsaved changes

### DIFF
--- a/app/assets/javascripts/stories.js
+++ b/app/assets/javascripts/stories.js
@@ -25,7 +25,49 @@ document.addEventListener("DOMContentLoaded", () => {
       debounceTimer = window.setTimeout(updateMarkdown, 300);
     });
   });
+
+  const form = document.querySelector('.edit_story');
+  const backButton = document.getElementById('back');
+  const logo = document.getElementById('logo');
+  let isDirty = false;
+
+  // Mark the form as dirty when any input changes
+  form.addEventListener('input', function () {
+    isDirty = true;
+  });
+
+  // Attach a click event to the custom back button
+  [backButton, logo].forEach(element => {
+    element.addEventListener('click', function (event) {
+      if (isDirty) {
+        const confirmLeave = confirm("You have unsaved changes. Are you sure you want to go back?");
+        if (!confirmLeave) {
+          // Prevent navigation if the user chooses not to leave
+          event.preventDefault();
+        } else {
+          // Optionally, reset isDirty if leaving
+          isDirty = false;
+        }
+      }
+    })
+  });
+
+  // Reset isDirty on form submission
+  form.addEventListener('submit', function () {
+    isDirty = false;
+  });
+
+  if (isDirty) {
+    window.addEventListener("beforeunload", warnUserifUnsavedEdits);
+  } else {
+    window.removeEventListener("beforeunload", warnUserifUnsavedEdits);
+  }
 });
+
+function warnUserifUnsavedEdits(event) {
+  event.preventDefault();
+  event.returnValue = '';
+}
 
 function updateStatusButton(color, status) {
   const button = document.querySelector(".story-title .dropdown-wrapper > button");

--- a/app/assets/javascripts/stories.js
+++ b/app/assets/javascripts/stories.js
@@ -26,19 +26,28 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   });
 
-  const form = document.querySelector('.edit_story');
-  const backButton = document.getElementById('back');
-  const logo = document.getElementById('logo');
+  const form = document.querySelector(".edit_story");
+  const backButton = document.getElementById("back");
+  const logo = document.getElementById("logo");
   let isDirty = false;
 
-  // Mark the form as dirty when any input changes
-  form.addEventListener('input', function () {
-    isDirty = true;
-  });
+  if (form) {
+    // Mark the form as dirty when any input changes
+    form.addEventListener("input", function () {
+      isDirty = true;
+      addBeforeUnloadEventListener(isDirty);
+    });
+
+    // Reset isDirty on form submission
+    form.addEventListener("submit", function () {
+      isDirty = false;
+      addBeforeUnloadEventListener(isDirty);
+    });
+  }
 
   // Attach a click event to the custom back button
   [backButton, logo].forEach(element => {
-    element.addEventListener('click', function (event) {
+    element.addEventListener("click", function (event) {
       if (isDirty) {
         const confirmLeave = confirm("You have unsaved changes. Are you sure you want to go back?");
         if (!confirmLeave) {
@@ -47,22 +56,20 @@ document.addEventListener("DOMContentLoaded", () => {
         } else {
           // Optionally, reset isDirty if leaving
           isDirty = false;
+          addBeforeUnloadEventListener(isDirty)
         }
       }
     })
   });
+});
 
-  // Reset isDirty on form submission
-  form.addEventListener('submit', function () {
-    isDirty = false;
-  });
-
+function addBeforeUnloadEventListener(isDirty) {
   if (isDirty) {
     window.addEventListener("beforeunload", warnUserifUnsavedEdits);
   } else {
     window.removeEventListener("beforeunload", warnUserifUnsavedEdits);
   }
-});
+}
 
 function warnUserifUnsavedEdits(event) {
   event.preventDefault();

--- a/app/assets/javascripts/stories.js
+++ b/app/assets/javascripts/stories.js
@@ -65,9 +65,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
 function addBeforeUnloadEventListener(isDirty) {
   if (isDirty) {
-    window.addEventListener("beforeunload", warnUserifUnsavedEdits);
+    window.addEventListener("beforeunload", warnUserIfUnsavedEdits);
   } else {
-    window.removeEventListener("beforeunload", warnUserifUnsavedEdits);
+    window.removeEventListener("beforeunload", warnUserIfUnsavedEdits);
   }
 }
 

--- a/app/assets/javascripts/stories.js
+++ b/app/assets/javascripts/stories.js
@@ -71,7 +71,7 @@ function addBeforeUnloadEventListener(isDirty) {
   }
 }
 
-function warnUserifUnsavedEdits(event) {
+function warnUserIfUnsavedEdits(event) {
   event.preventDefault();
   event.returnValue = '';
 }

--- a/app/assets/javascripts/stories.js
+++ b/app/assets/javascripts/stories.js
@@ -1,4 +1,20 @@
-document.addEventListener("DOMContentLoaded", () => {
+// Single source of truth for the unsaved-changes wording. It is shown for
+// every in-app link the user might leave through. The native beforeunload
+// prompt (reload / closing the tab) always uses the browser's own generic
+// text; browsers ignore any custom string there, so that one case aside, this
+// keeps the wording consistent everywhere we can control it.
+const UNSAVED_CHANGES_MESSAGE =
+  "You have unsaved changes. Are you sure you want to leave?";
+
+// Init on turbolinks:load (not DOMContentLoaded) so it also runs on Turbolinks
+// visits, matching project.js. reloadable state lives at module scope so the
+// delegated click handler can be added by reference and de-duplicated across
+// visits instead of stacking a new listener each time.
+let editForm = null;
+let editFormInitialState = null;
+let editFormDirty = false;
+
+document.addEventListener("turbolinks:load", () => {
   document.querySelectorAll("[data-has-preview]").forEach((element) => {
     let debounceTimer;
 
@@ -26,52 +42,69 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   });
 
-  const form = document.querySelector(".edit_story");
-  const backButton = document.getElementById("back");
-  const logo = document.getElementById("logo");
-  let isDirty = false;
+  initUnsavedChangesGuard();
+});
 
-  if (form) {
-    // Snapshot the initial form state so we can compare against it. Tracking a
-    // plain "changed at least once" flag reported the form as dirty even after
-    // the user undid their edits (e.g. typed some text and then deleted it).
-    const initialState = serializeForm(form);
+function initUnsavedChangesGuard() {
+  editForm = document.querySelector(".edit_story");
+  editFormDirty = false;
+  // Start each visit from a clean slate; drop any beforeunload guard carried
+  // over from a previous page.
+  addBeforeUnloadEventListener(false);
 
-    const refreshDirtyState = function () {
-      isDirty = serializeForm(form) !== initialState;
-      addBeforeUnloadEventListener(isDirty);
-    };
-
-    // "input" covers text fields; "change" covers selects like the status.
-    form.addEventListener("input", refreshDirtyState);
-    form.addEventListener("change", refreshDirtyState);
-
-    // Reset isDirty on form submission
-    form.addEventListener("submit", function () {
-      isDirty = false;
-      addBeforeUnloadEventListener(isDirty);
-    });
+  if (!editForm) {
+    return;
   }
 
-  // Attach a click event to the custom back button
-  [backButton, logo].forEach(element => {
-    if (!element) return;
+  // Snapshot the initial form state so we can compare against it. Tracking a
+  // plain "changed at least once" flag reported the form as dirty even after
+  // the user undid their edits (e.g. typed some text and then deleted it).
+  editFormInitialState = serializeForm(editForm);
 
-    element.addEventListener("click", function (event) {
-      if (isDirty) {
-        const confirmLeave = confirm("You have unsaved changes. Are you sure you want to go back?");
-        if (confirmLeave) {
-          // Optionally, reset isDirty if leaving
-          isDirty = false;
-          addBeforeUnloadEventListener(isDirty)
-        } else {
-          // Prevent navigation if the user chooses not to leave
-          event.preventDefault();
-        }
-      }
-    })
-  });
-});
+  // "input" covers text fields; "change" covers selects like the status.
+  editForm.addEventListener("input", refreshEditFormDirtyState);
+  editForm.addEventListener("change", refreshEditFormDirtyState);
+  editForm.addEventListener("submit", clearEditFormDirtyState);
+
+  // Same warning for every in-app link that leaves the page (Back, the logo,
+  // Sign out, ...), not just a couple of buttons. Added by reference so it is
+  // de-duplicated if turbolinks:load fires again.
+  document.addEventListener("click", confirmLeaveIfUnsavedEdits);
+}
+
+function refreshEditFormDirtyState() {
+  editFormDirty = serializeForm(editForm) !== editFormInitialState;
+  addBeforeUnloadEventListener(editFormDirty);
+}
+
+function clearEditFormDirtyState() {
+  editFormDirty = false;
+  addBeforeUnloadEventListener(false);
+}
+
+function confirmLeaveIfUnsavedEdits(event) {
+  if (!editFormDirty) {
+    return;
+  }
+
+  const link = event.target.closest("a[href]");
+  if (!link) {
+    return;
+  }
+
+  // Links that do not actually leave the page (new tab, in-page anchors,
+  // javascript: handlers) should not trigger the warning.
+  const href = link.getAttribute("href") || "";
+  if (link.target === "_blank" || href.startsWith("#") || href.startsWith("javascript:")) {
+    return;
+  }
+
+  if (window.confirm(UNSAVED_CHANGES_MESSAGE)) {
+    clearEditFormDirtyState();
+  } else {
+    event.preventDefault();
+  }
+}
 
 function serializeForm(form) {
   return new URLSearchParams(new FormData(form)).toString();
@@ -87,7 +120,7 @@ function addBeforeUnloadEventListener(isDirty) {
 
 function warnUserIfUnsavedEdits(event) {
   event.preventDefault();
-  event.returnValue = '';
+  event.returnValue = UNSAVED_CHANGES_MESSAGE;
 }
 
 function updateStatusButton(color, status) {

--- a/app/assets/javascripts/stories.js
+++ b/app/assets/javascripts/stories.js
@@ -50,13 +50,13 @@ document.addEventListener("DOMContentLoaded", () => {
     element.addEventListener("click", function (event) {
       if (isDirty) {
         const confirmLeave = confirm("You have unsaved changes. Are you sure you want to go back?");
-        if (!confirmLeave) {
-          // Prevent navigation if the user chooses not to leave
-          event.preventDefault();
-        } else {
+        if (confirmLeave) {
           // Optionally, reset isDirty if leaving
           isDirty = false;
           addBeforeUnloadEventListener(isDirty)
+        } else {
+          // Prevent navigation if the user chooses not to leave
+          event.preventDefault();
         }
       }
     })

--- a/app/assets/javascripts/stories.js
+++ b/app/assets/javascripts/stories.js
@@ -32,11 +32,19 @@ document.addEventListener("DOMContentLoaded", () => {
   let isDirty = false;
 
   if (form) {
-    // Mark the form as dirty when any input changes
-    form.addEventListener("input", function () {
-      isDirty = true;
+    // Snapshot the initial form state so we can compare against it. Tracking a
+    // plain "changed at least once" flag reported the form as dirty even after
+    // the user undid their edits (e.g. typed some text and then deleted it).
+    const initialState = serializeForm(form);
+
+    const refreshDirtyState = function () {
+      isDirty = serializeForm(form) !== initialState;
       addBeforeUnloadEventListener(isDirty);
-    });
+    };
+
+    // "input" covers text fields; "change" covers selects like the status.
+    form.addEventListener("input", refreshDirtyState);
+    form.addEventListener("change", refreshDirtyState);
 
     // Reset isDirty on form submission
     form.addEventListener("submit", function () {
@@ -47,6 +55,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Attach a click event to the custom back button
   [backButton, logo].forEach(element => {
+    if (!element) return;
+
     element.addEventListener("click", function (event) {
       if (isDirty) {
         const confirmLeave = confirm("You have unsaved changes. Are you sure you want to go back?");
@@ -62,6 +72,10 @@ document.addEventListener("DOMContentLoaded", () => {
     })
   });
 });
+
+function serializeForm(form) {
+  return new URLSearchParams(new FormData(form)).toString();
+}
 
 function addBeforeUnloadEventListener(isDirty) {
   if (isDirty) {

--- a/spec/features/projects_manage_spec.rb
+++ b/spec/features/projects_manage_spec.rb
@@ -266,9 +266,9 @@ RSpec.describe "managing projects", js: true do
 
           last_project = Project.parents.last
           expect(last_project.id).not_to eq(project.id)
-          expect(last_project.projects.count).to eq 2
-          expect(last_project.projects[0].title).to eq sub_project1.title
-          expect(last_project.projects[1].title).to eq sub_project3.title
+          expect(last_project.projects.map(&:title)).to contain_exactly(
+            sub_project1.title, sub_project3.title
+          )
         end
 
         it "allows to select/unselect all sub-projects at once" do

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -68,6 +68,17 @@ RSpec.describe "managing stories", js: true do
     expect(page).to have_content "Story updated!"
   end
 
+  it "alerts me when I try to navigate away from the page without saving my edits", js: true do
+    visit project_path(id: project.id)
+    click_button "More actions"
+    click_link "Edit"
+    fill_in "story[title]", with: "As a user, I want to edit stories"
+    click_link "Back"
+    alert_text = page.driver.browser.switch_to.alert.text
+
+    expect(alert_text).to eq "You have unsaved changes. Are you sure you want to go back?"
+  end
+
   it "allows me to delete a story" do
     visit project_path(id: project.id)
 

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -72,11 +72,26 @@ RSpec.describe "managing stories", js: true do
     visit project_path(id: project.id)
     click_button "More actions"
     click_link "Edit"
-    fill_in "story[title]", with: "As a user, I want to edit stories"
-    click_link "Back"
-    alert_text = page.driver.browser.switch_to.alert.text
 
-    expect(alert_text).to eq "You have unsaved changes. Are you sure you want to go back?"
+    click_link "Back"
+    assert_current_path project_path(id: project.id)
+
+    click_button "More actions"
+    click_link "Edit"
+
+    fill_in "story[title]", with: "As a user, I want to edit stories"
+
+    dismiss_confirm("You have unsaved changes. Are you sure you want to go back?") do
+      find("#logo").click
+    end
+
+    assert_current_path edit_project_story_path(project, story)
+
+    accept_confirm("You have unsaved changes. Are you sure you want to go back?") do
+      click_link "Back"
+    end
+
+    assert_current_path project_path(id: project.id)
   end
 
   it "allows me to delete a story" do

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -94,6 +94,20 @@ RSpec.describe "managing stories", js: true do
     assert_current_path project_path(id: project.id)
   end
 
+  it "does not alert me when I revert my edits back to their original values", js: true do
+    visit edit_project_story_path(project, story)
+    original_title = find_field("story[title]").value
+
+    # Make a change and then undo it, returning the form to its initial state.
+    fill_in "story[title]", with: "A temporary edit"
+    fill_in "story[title]", with: original_title
+
+    # No unsaved-changes confirm should appear, so navigation happens directly.
+    click_link "Back"
+
+    assert_current_path project_path(id: project.id)
+  end
+
   it "allows me to delete a story" do
     visit project_path(id: project.id)
 

--- a/spec/features/stories_manage_spec.rb
+++ b/spec/features/stories_manage_spec.rb
@@ -81,13 +81,13 @@ RSpec.describe "managing stories", js: true do
 
     fill_in "story[title]", with: "As a user, I want to edit stories"
 
-    dismiss_confirm("You have unsaved changes. Are you sure you want to go back?") do
+    dismiss_confirm("You have unsaved changes. Are you sure you want to leave?") do
       find("#logo").click
     end
 
     assert_current_path edit_project_story_path(project, story)
 
-    accept_confirm("You have unsaved changes. Are you sure you want to go back?") do
+    accept_confirm("You have unsaved changes. Are you sure you want to leave?") do
       click_link "Back"
     end
 


### PR DESCRIPTION
### Jira Ticket 
https://ombulabs.atlassian.net/browse/DT-340

### Motivation / Context
Currently if you leave the current page, you can lose information that was not saved. This feature warns you if you are leaving without saving information.
    
### QA / Testing Instructions
1. Go to the Edit Story page.
2. Edit the story.
3. Try to navigate off the page by reloading, pressing the back button in the browser, clicking the logo or the Back button on the page.
4. Ensure that you get a popup asking you if are sure you want to reload/go back.

### Screenshots:

<img width="1071" alt="Screenshot 2024-11-07 at 1 53 28 PM" src="https://github.com/user-attachments/assets/629253ae-fc55-442b-b643-43a164282df5">

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).
