### PR TITLE
Fix bundle install on macOS by adding darwin platforms to Gemfile.next.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -473,6 +473,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-linux

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -223,6 +223,10 @@ GEM
     nokogiri (1.18.8)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.18.8-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.8-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-gnu)
       racc (~> 1.4)
     oauth2 (2.0.9)
@@ -463,7 +467,11 @@ GEM
     zeitwerk (2.7.2)
 
 PLATFORMS
+  arm64-darwin-23
+  arm64-darwin-24
   ruby
+  x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
## Summary

- `BUNDLE_GEMFILE=Gemfile.next bundle install` was failing on macOS (arm64) because `Gemfile.next.lock` only listed the `ruby` and `x86_64-linux` platforms. Bundler fell back to building nokogiri from source, which fails locally with `fatal error: 'nokogiri_gumbo.h' file not found`.
- Added the darwin platforms (`arm64-darwin-23/24`, `x86_64-darwin-21/22`) to `Gemfile.next.lock` so the precompiled native gems are used, matching the platform set already present in `Gemfile.lock`.
- Also picked up `arm64-darwin-24` in `Gemfile.lock` (previously uncommitted local diff).

## Test plan

- [x] `bundle exec rubocop` — 120 files, 0 offenses.
- [x] `BUNDLE_GEMFILE=Gemfile.next bundle exec rubocop` — 120 files, 0 offenses.
- [x] `bundle install` (current Rails) — succeeds.
- [x] `BUNDLE_GEMFILE=Gemfile.next bundle install` — succeeds (176 gems).
- [x] `bundle exec rspec` against current Rails — 204 examples, 0 failures.
- [x] `BUNDLE_GEMFILE=Gemfile.next bundle exec rspec` against next Rails — 204 examples, 0 failures.
