### PR TITLE
Add ostruct gem to fix production boot on Ruby 3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,4 +108,6 @@ gem "coffee-script"
 
 gem "pundit", "~> 2.2"
 
+gem "ostruct"
+
 gem "madmin", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,6 +273,7 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
+    ostruct (0.6.3)
     pagy (6.1.0)
     parallel (2.1.0)
     parser (3.3.12.0)
@@ -526,6 +527,7 @@ DEPENDENCIES
   newrelic_rpm
   next_rails
   ombu_labs-auth
+  ostruct
   pg
   puma (~> 7.2)
   pundit (~> 2.2)

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -564,6 +564,7 @@ DEPENDENCIES
   newrelic_rpm
   next_rails
   ombu_labs-auth
+  ostruct
   pg
   puma (~> 7.2)
   pundit (~> 2.2)


### PR DESCRIPTION
## Hotfix: restore production boot on Ruby 3.4

Production (`points-production`) is down. Puma crashes on boot and every request returns 503 (`H10 App crashed`).

### Root cause

```
madmin-1.2.8/lib/madmin/resource.rb:39:in 'attribute':
uninitialized constant OpenStruct (NameError)
```

Ruby 3.4 removed `ostruct` from the default gems, it is now a bundled gem that must be declared in the `Gemfile`. madmin 1.2.8 uses `OpenStruct` without `require "ostruct"`, so on Ruby 3.4 the constant is undefined, boot fails, and the app crashes.

madmin's `rescue` in `resource.rb` re-raises the `NameError` as a misleading `ArgumentError: couldn't find attribute 'id' on Estimate model`, which masks the real cause in the logs.

### Fix

Declare `gem "ostruct"` so `Bundler.require` loads it at boot and `OpenStruct` is defined. Applied to both `Gemfile.lock` and `Gemfile.next.lock`.

### Scope

Minimal, reversible hotfix to get production back up. The madmin 2.x upgrade (#371) is the longer-term fix and removes this incompatibility entirely.
