### PR TITLE
Fix flaky madmin projects spec and Devise mappings on Rails 8.1

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -132,6 +132,14 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  # Rails 8.1 loads routes lazily. Devise registers its mappings while the
+  # routes are drawn (via devise_for), so until the routes are loaded
+  # Devise.mappings is empty and sign_in raises "Could not find a valid
+  # mapping". Force the routes to load before the suite runs.
+  config.before(:suite) do
+    Rails.application.reload_routes_unless_loaded
+  end
+
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
   end

--- a/spec/requests/madmin/projects_spec.rb
+++ b/spec/requests/madmin/projects_spec.rb
@@ -13,7 +13,10 @@ RSpec.describe "Madmin projects", type: :request do
       get "/madmin/projects"
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include(project.title)
+      # The title is HTML-escaped in the rendered page (e.g. an apostrophe
+      # becomes &#39;), so compare against the escaped form to avoid a flaky
+      # failure whenever Faker generates a name with special characters.
+      expect(response.body).to include(CGI.escapeHTML(project.title))
     end
   end
 


### PR DESCRIPTION
### Motivation / Context

This PR fixes two independent test-suite problems that were making CI red.

#### 1. Flaky `madmin/projects` spec (build-rails-current)

`spec/requests/madmin/projects_spec.rb` asserted the raw project title appears in the rendered page:

```ruby
expect(response.body).to include(project.title)
```

The title is HTML-escaped when rendered (an apostrophe becomes `&#39;`, an ampersand `&amp;`, etc.). The factory uses `Faker::Company.name`, which sometimes generates names with these characters (e.g. `O'Conner, Reichel and Sanford`), so the assertion failed intermittently depending on the random name. Fixed by comparing against `CGI.escapeHTML(project.title)`.

#### 2. Devise mappings empty on Rails 8.1 (build-rails-next)

Every controller-spec `sign_in` raised `Could not find a valid mapping for #<User ...>` on the `build-rails-next` lane (Rails 8.1), causing 34 failures. Rails 8.1 loads routes lazily, and Devise registers its scope mappings while the routes are drawn (`devise_for`). Until the routes load, `Devise.mappings` is empty, so `Devise::Mapping.find_scope!` iterates nothing and raises, even though the specs set `@request.env["devise.mapping"]`.

Fixed by forcing the routes to load in a `before(:suite)` hook:

```ruby
Rails.application.reload_routes_unless_loaded
```

This is harmless on Rails 8.0 (routes are already loaded there) and repopulates the mappings on Rails 8.1.

### QA / Testing Instructions

1. `bundle exec rspec` on the current Gemfile: green.
2. `BUNDLE_GEMFILE=Gemfile.next bundle exec rspec`: green (previously 34 `sign_in` failures).

___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).
